### PR TITLE
Add baseline algorithms data generation (A* with h(n) = 0 ; max depth <= 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,93 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual Environments
+venv/
+venv312/
+env/
+ENV/
+env.bak/
+venv.bak/
+.venv/
+.venv312/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pytest
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# LaTeX
+*.aux
+*.log
+*.out
+*.toc
+*.synctex.gz
+*.fdb_latexmk
+*.fls
+*.bbl
+*.blg
+*.bcf
+*.run.xml
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Project specific
+results/h2_constant_tests/*.json
+results/h2_constant_tests/*.txt
+*.mov
+*.mp4

--- a/experiments/compare_heuristics_live.py
+++ b/experiments/compare_heuristics_live.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import sys
 import time
 import random
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Dict, Tuple, List, Any
@@ -26,9 +28,14 @@ from scripts.weighted_astar import (
     weighted_astar_best_path,
     PlanResult as WeightedPlanResult,
 )
+from scripts.baseline_algorithms import (
+    simple_1hop_arbitrage,
+    simple_2hop_arbitrage,
+    PlanResult as BaselinePlanResult,
+)
 
-# Result from either classic A* or weighted A*
-PlanLike = AStarPlanResult | WeightedPlanResult
+# Result from either classic A*, weighted A*, or baseline algorithms
+PlanLike = AStarPlanResult | WeightedPlanResult | BaselinePlanResult
 
 # -------------------------------------------------------------------
 # "Quick experiment" knobs (tuned so it doesn't take an hour)
@@ -38,6 +45,7 @@ QUICK_MAX_TIME_SEC: float = 60.0  # ≈ 1 minute cap per search (best-effort)
 QUICK_NUM_START_NODES: int = 3    # use at most 3 start nodes
 QUICK_NUM_STARTS_H3: int = 2      # parallel random starts for h3
 QUICK_CASH_LEVELS: List[float] = [1_000.0, 10_000.0, 100_000.0]
+MAX_WORKERS: int = 8              # number of parallel threads for running searches
 
 
 @dataclass
@@ -69,6 +77,8 @@ def run_single_search(
       - "h2_slippage"   -> astar_best_path_with_liquidity using h2
       - "h4_chaincongestion_exchange_risk" -> weighted_astar_best_path (h4+h5)
       - "h3_parallel"   -> parallel_search_from_random_starts (wrapper over A*)
+      - "simple_1hop"   -> simple_1hop_arbitrage (naive 1-hop baseline)
+      - "simple_2hop"   -> simple_2hop_arbitrage (naive 2-hop baseline)
     """
     t0 = time.perf_counter()
     error: Optional[str] = None
@@ -111,11 +121,31 @@ def run_single_search(
                 min_profit_usd=min_profit_usd,
             )
 
+        elif heuristic == "simple_1hop":
+            if start_node is None:
+                raise ValueError("start_node must be provided for simple_1hop")
+            result = simple_1hop_arbitrage(
+                start_node=start_node,
+                liquid_cash_usd=cash_usd,
+                max_time_sec=max_time_sec,
+                min_profit_usd=min_profit_usd,
+            )
+
+        elif heuristic == "simple_2hop":
+            if start_node is None:
+                raise ValueError("start_node must be provided for simple_2hop")
+            result = simple_2hop_arbitrage(
+                start_node=start_node,
+                liquid_cash_usd=cash_usd,
+                max_time_sec=max_time_sec,
+                min_profit_usd=min_profit_usd,
+            )
+
         else:
             raise ValueError(
                 f"Unknown heuristic: {heuristic}. Must be one of "
                 f"'h1_liquidity', 'h2_slippage', 'h3_parallel', "
-                f"'h4_chaincongestion_exchange_risk'."
+                f"'h4_chaincongestion_exchange_risk', 'simple_1hop', 'simple_2hop'."
             )
 
     except Exception as e:
@@ -176,84 +206,127 @@ def pick_start_nodes(nodes: Dict[NodeId, dict]) -> List[NodeId]:
 
 
 def main() -> None:
-    # Collect all printed lines so we can also save them to a .txt file
-    logs: List[str] = []
-
-    def log(msg: str = "") -> None:
-        """Print to console and also store in logs list."""
+    # Setup output file with incremental writing
+    results_dir = project_root / "results"
+    results_dir.mkdir(exist_ok=True)
+    out_path = results_dir / "compare_heuristics_live.txt"
+    
+    # Thread-safe file writing
+    file_lock = threading.Lock()
+    all_results: List[ExperimentResult] = []
+    results_lock = threading.Lock()
+    
+    def log_and_write(msg: str = "", flush: bool = False) -> None:
+        """Print to console and immediately write to file (thread-safe)."""
         print(msg)
-        logs.append(msg)
-
-    log("=== Building graph ===")
+        with file_lock:
+            with out_path.open("a", encoding="utf-8") as f:
+                f.write(msg + "\n")
+                if flush:
+                    f.flush()
+    
+    # Clear previous results and write header
+    with out_path.open("w", encoding="utf-8") as f:
+        f.write("=== Heuristic Comparison Experiments ===\n")
+        f.write(f"Started: {time.strftime('%Y-%m-%d %H:%M:%S')}\n\n")
+    
+    log_and_write("=== Building graph ===")
     nodes, _ = build_graph()
-    log(f"Graph has {len(nodes)} nodes")
+    log_and_write(f"Graph has {len(nodes)} nodes")
 
     # Choose starting nodes for h1/h2/h4 experiments
     start_nodes = pick_start_nodes(nodes)
-    log("\nUsing start nodes:")
+    log_and_write("\nUsing start nodes:")
     for n in start_nodes:
-        log(f"  - {n[0]}:{n[1]}")
+        log_and_write(f"  - {n[0]}:{n[1]}")
 
     # Different order sizes we want to test (quick settings)
     cash_levels = QUICK_CASH_LEVELS
+    
+    log_and_write(f"\nRunning with {MAX_WORKERS} parallel workers\n")
 
-    all_results: List[ExperimentResult] = []
-
-    # ---- Run experiments ----
+    # ---- Run experiments in parallel ----
     for cash in cash_levels:
-        log("\n============================")
-        log(f"Order size: ${cash:,.2f}")
-        log("============================")
+        log_and_write("\n============================")
+        log_and_write(f"Order size: ${cash:,.2f}")
+        log_and_write("============================")
 
+        # Build list of all tasks to run in parallel
+        tasks: List[Tuple[str, Optional[NodeId], float]] = []
+        
         # h1 + h2 + h4: run for each start node
         for start in start_nodes:
             for h in ["h1_liquidity", "h2_slippage", "h4_chaincongestion_exchange_risk"]:
-                log(f"\nRunning {h} from {start[0]}:{start[1]} ...")
-                res = run_single_search(
-                    heuristic=h,
-                    cash_usd=cash,
-                    start_node=start,
-                )
-                all_results.append(res)
-
-                if res.success:
-                    log(
-                        f"  SUCCESS: final=${res.final_cash_usd:.2f} "
-                        f"(profit=${res.profit_usd:.2f}), "
-                        f"path_len={res.path_len}, "
-                        f"time={res.duration_sec:.3f}s"
-                    )
-                else:
-                    log(
-                        f"  FAIL: {res.error} "
-                        f"(time={res.duration_sec:.3f}s)"
-                    )
-
+                tasks.append((h, start, cash))
+        
+        # Simple baselines: run for each start node
+        for start in start_nodes:
+            for h in ["simple_1hop", "simple_2hop"]:
+                tasks.append((h, start, cash))
+        
         # h3_parallel: start nodes are chosen inside the function
-        log("\nRunning h3_parallel (random starts) ...")
-        res_parallel = run_single_search(
-            heuristic="h3_parallel",
-            cash_usd=cash,
-            start_node=None,
-        )
-        all_results.append(res_parallel)
-
-        if res_parallel.success:
-            log(
-                f"  h3_parallel SUCCESS: final=${res_parallel.final_cash_usd:.2f} "
-                f"(profit=${res_parallel.profit_usd:.2f}), "
-                f"path_len={res_parallel.path_len}, "
-                f"time={res_parallel.duration_sec:.3f}s"
+        tasks.append(("h3_parallel", None, cash))
+        
+        # Run all tasks in parallel
+        def run_task(heuristic: str, start: Optional[NodeId], cash_val: float) -> ExperimentResult:
+            """Wrapper function for parallel execution."""
+            start_str = (
+                "random_parallel"
+                if start is None
+                else f"{start[0]}:{start[1]}"
             )
-        else:
-            log(
-                f"  h3_parallel FAIL: {res_parallel.error} "
-                f"(time={res_parallel.duration_sec:.3f}s)"
+            log_and_write(f"\n[START] Running {heuristic} from {start_str} (cash=${cash_val:,.2f}) ...", flush=True)
+            
+            res = run_single_search(
+                heuristic=heuristic,
+                cash_usd=cash_val,
+                start_node=start,
             )
+            
+            # Thread-safe result storage
+            with results_lock:
+                all_results.append(res)
+            
+            # Log result immediately
+            if res.success:
+                log_and_write(
+                    f"[DONE] {heuristic} from {start_str}: SUCCESS - "
+                    f"final=${res.final_cash_usd:.2f} "
+                    f"(profit=${res.profit_usd:.2f}), "
+                    f"path_len={res.path_len}, "
+                    f"time={res.duration_sec:.3f}s",
+                    flush=True
+                )
+            else:
+                log_and_write(
+                    f"[DONE] {heuristic} from {start_str}: FAIL - {res.error} "
+                    f"(time={res.duration_sec:.3f}s)",
+                    flush=True
+                )
+            
+            return res
+        
+        # Execute all tasks in parallel
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {
+                executor.submit(run_task, h, start, cash): (h, start, cash)
+                for h, start, cash in tasks
+            }
+            
+            # Wait for all to complete (results are logged as they finish)
+            for future in as_completed(futures):
+                try:
+                    future.result()  # This will raise any exceptions
+                except Exception as e:
+                    heuristic, start_node, cash_val = futures[future]
+                    log_and_write(
+                        f"[ERROR] {heuristic} from {start_node}: Exception - {str(e)}",
+                        flush=True
+                    )
 
     # ---- Compact summary at the end ----
-    log("\n\n================ SUMMARY ================")
-    for res in all_results:
+    log_and_write("\n\n================ SUMMARY ================")
+    for res in sorted(all_results, key=lambda x: (x.cash_usd, x.heuristic, str(x.start_node))):
         start_str = (
             "random_parallel"
             if res.start_node is None
@@ -270,7 +343,7 @@ def main() -> None:
             if res.profit_usd is not None
             else "N/A"
         )
-        log(
+        log_and_write(
             f"[{status}] h={res.heuristic:30s} "
             f"start={start_str:18s} "
             f"cash=${res.cash_usd:9,.2f} "
@@ -279,14 +352,9 @@ def main() -> None:
             f"len={str(res.path_len):>3s} "
             f"time={res.duration_sec:6.3f}s"
         )
-
-    # ---- Write logs to results/compare_heuristics_live.txt ----
-    results_dir = project_root / "results"
-    results_dir.mkdir(exist_ok=True)
-    out_path = results_dir / "compare_heuristics_live.txt"
-
-    out_path.write_text("\n".join(logs) + "\n", encoding="utf-8")
-    log(f"\nSaved experiment log to: {out_path}")
+    
+    log_and_write(f"\nCompleted: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    log_and_write(f"\nSaved experiment log to: {out_path}")
 
 
 if __name__ == "__main__":

--- a/experiments/monte_carlo_simulation.py
+++ b/experiments/monte_carlo_simulation.py
@@ -30,9 +30,14 @@ from scripts.weighted_astar import (
     weighted_astar_best_path,
     PlanResult as WeightedPlanResult,
 )
+from scripts.baseline_algorithms import (
+    simple_1hop_arbitrage,
+    simple_2hop_arbitrage,
+    PlanResult as BaselinePlanResult,
+)
 
-# Both A* and Weighted A* return a PlanResult-like object
-PlanLike = AStarPlanResult | WeightedPlanResult
+# Both A*, Weighted A*, and baseline algorithms return a PlanResult-like object
+PlanLike = AStarPlanResult | WeightedPlanResult | BaselinePlanResult
 
 # ----------------------------------------------------------------------
 # "Quick" Monte Carlo knobs so it doesn't run forever
@@ -81,6 +86,8 @@ def run_single_search(
       - "h2_slippage"   -> astar_best_path_with_liquidity using h2
       - "h4_chaincongestion_exchange_risk" -> weighted_astar_best_path (h4+h5)
       - "h3_parallel"   -> parallel_search_from_random_starts (wrapper over A*)
+      - "simple_1hop"   -> simple_1hop_arbitrage (naive 1-hop baseline)
+      - "simple_2hop"   -> simple_2hop_arbitrage (naive 2-hop baseline)
     """
     t0 = time.perf_counter()
     error: Optional[str] = None
@@ -122,11 +129,31 @@ def run_single_search(
                 min_profit_usd=min_profit_usd,
             )
 
+        elif heuristic == "simple_1hop":
+            if start_node is None:
+                raise ValueError("start_node must be provided for simple_1hop")
+            result = simple_1hop_arbitrage(
+                start_node=start_node,
+                liquid_cash_usd=cash_usd,
+                max_time_sec=max_time_sec,
+                min_profit_usd=min_profit_usd,
+            )
+
+        elif heuristic == "simple_2hop":
+            if start_node is None:
+                raise ValueError("start_node must be provided for simple_2hop")
+            result = simple_2hop_arbitrage(
+                start_node=start_node,
+                liquid_cash_usd=cash_usd,
+                max_time_sec=max_time_sec,
+                min_profit_usd=min_profit_usd,
+            )
+
         else:
             raise ValueError(
                 f"Unknown heuristic: {heuristic}. Must be one of "
                 f"'h1_liquidity', 'h2_slippage', 'h4_chaincongestion_exchange_risk', "
-                f"'h3_parallel'."
+                f"'h3_parallel', 'simple_1hop', 'simple_2hop'."
             )
 
     except Exception as e:
@@ -202,6 +229,8 @@ def main():
         "h2_slippage",
         "h4_chaincongestion_exchange_risk",
         "h3_parallel",
+        "simple_1hop",
+        "simple_2hop",
     ]
 
     all_results: List[MonteCarloResult] = []
@@ -225,7 +254,8 @@ def main():
             for trial_idx in range(1, NUM_TRIALS + 1):
                 cash = random.choice(CASH_LEVELS)
 
-                if h in ("h1_liquidity", "h2_slippage", "h4_chaincongestion_exchange_risk"):
+                if h in ("h1_liquidity", "h2_slippage", "h4_chaincongestion_exchange_risk", 
+                         "simple_1hop", "simple_2hop"):
                     start = pick_random_start_node(nodes)
                 else:
                     start = None  # h3_parallel chooses its own starts

--- a/results/compare_heuristics_live.txt
+++ b/results/compare_heuristics_live.txt
@@ -1,142 +1,224 @@
+=== Heuristic Comparison Experiments ===
+Started: 2026-01-21 20:54:21
+
 === Building graph ===
-Graph has 19 nodes
+Graph has 21 nodes
 
 Using start nodes:
   - binance:BUSD
   - binance:USDT
   - kraken:USDT
 
+Running with 8 parallel workers
+
+
 ============================
 Order size: $1,000.00
 ============================
 
-Running h1_liquidity from binance:BUSD ...
-  SUCCESS: final=$1003.20 (profit=$3.20), path_len=6, time=53.128s
+[START] Running h1_liquidity from binance:BUSD (cash=$1,000.00) ...
 
-Running h2_slippage from binance:BUSD ...
-  SUCCESS: final=$1003.20 (profit=$3.20), path_len=4, time=55.930s
+[START] Running h2_slippage from binance:BUSD (cash=$1,000.00) ...
 
-Running h4_chaincongestion_exchange_risk from binance:BUSD ...
-  SUCCESS: final=$1003.20 (profit=$3.20), path_len=4, time=4.176s
+[START] Running h4_chaincongestion_exchange_risk from binance:BUSD (cash=$1,000.00) ...
 
-Running h1_liquidity from binance:USDT ...
-  SUCCESS: final=$1004.15 (profit=$4.15), path_len=3, time=74.937s
+[START] Running h1_liquidity from binance:USDT (cash=$1,000.00) ...
 
-Running h2_slippage from binance:USDT ...
-  SUCCESS: final=$1004.15 (profit=$4.15), path_len=3, time=62.756s
+[START] Running h2_slippage from binance:USDT (cash=$1,000.00) ...
 
-Running h4_chaincongestion_exchange_risk from binance:USDT ...
-  SUCCESS: final=$1004.15 (profit=$4.15), path_len=3, time=5.439s
+[START] Running h4_chaincongestion_exchange_risk from binance:USDT (cash=$1,000.00) ...
 
-Running h1_liquidity from kraken:USDT ...
-  SUCCESS: final=$1004.14 (profit=$4.14), path_len=3, time=80.685s
+[START] Running h1_liquidity from kraken:USDT (cash=$1,000.00) ...
 
-Running h2_slippage from kraken:USDT ...
-  SUCCESS: final=$1004.14 (profit=$4.14), path_len=3, time=61.500s
+[START] Running h2_slippage from kraken:USDT (cash=$1,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from binance:USDT: FAIL - No profitable path found (time=5.927s)
 
-Running h4_chaincongestion_exchange_risk from kraken:USDT ...
-  SUCCESS: final=$1004.14 (profit=$4.14), path_len=3, time=5.178s
+[START] Running h4_chaincongestion_exchange_risk from kraken:USDT (cash=$1,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from binance:BUSD: SUCCESS - final=$1000.15 (profit=$0.15), path_len=2, time=6.212s
 
-Running h3_parallel (random starts) ...
-  h3_parallel SUCCESS: final=$1004.15 (profit=$4.15), path_len=3, time=92.559s
+[START] Running simple_1hop from binance:BUSD (cash=$1,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from kraken:USDT: FAIL - No profitable path found (time=7.236s)
+
+[START] Running simple_2hop from binance:BUSD (cash=$1,000.00) ...
+[DONE] simple_1hop from binance:BUSD: FAIL - No profitable path found (time=7.533s)
+
+[START] Running simple_1hop from binance:USDT (cash=$1,000.00) ...
+[DONE] simple_2hop from binance:BUSD: FAIL - No profitable path found (time=8.344s)
+
+[START] Running simple_2hop from binance:USDT (cash=$1,000.00) ...
+[DONE] simple_1hop from binance:USDT: FAIL - No profitable path found (time=8.219s)
+
+[START] Running simple_1hop from kraken:USDT (cash=$1,000.00) ...
+[DONE] simple_2hop from binance:USDT: FAIL - No profitable path found (time=7.100s)
+
+[START] Running simple_2hop from kraken:USDT (cash=$1,000.00) ...
+[DONE] simple_1hop from kraken:USDT: FAIL - No profitable path found (time=7.413s)
+
+[START] Running h3_parallel from random_parallel (cash=$1,000.00) ...
+[DONE] simple_2hop from kraken:USDT: FAIL - No profitable path found (time=7.837s)
+[DONE] h2_slippage from binance:BUSD: SUCCESS - final=$1000.15 (profit=$0.15), path_len=2, time=73.716s
+[DONE] h2_slippage from binance:USDT: FAIL - No profitable path found (time=73.787s)
+[DONE] h2_slippage from kraken:USDT: FAIL - No profitable path found (time=74.258s)
+[DONE] h1_liquidity from binance:BUSD: SUCCESS - final=$1000.15 (profit=$0.15), path_len=2, time=85.299s
+[DONE] h1_liquidity from kraken:USDT: FAIL - No profitable path found (time=105.381s)
+[DONE] h1_liquidity from binance:USDT: FAIL - No profitable path found (time=106.316s)
+[DONE] h3_parallel from random_parallel: SUCCESS - final=$1210.00 (profit=$210.00), path_len=2, time=108.574s
 
 ============================
 Order size: $10,000.00
 ============================
 
-Running h1_liquidity from binance:BUSD ...
-  SUCCESS: final=$10031.96 (profit=$31.96), path_len=5, time=80.060s
+[START] Running h1_liquidity from binance:BUSD (cash=$10,000.00) ...
 
-Running h2_slippage from binance:BUSD ...
-  SUCCESS: final=$10032.47 (profit=$32.47), path_len=4, time=53.051s
+[START] Running h2_slippage from binance:BUSD (cash=$10,000.00) ...
 
-Running h4_chaincongestion_exchange_risk from binance:BUSD ...
-  SUCCESS: final=$10032.97 (profit=$32.97), path_len=4, time=4.219s
+[START] Running h4_chaincongestion_exchange_risk from binance:BUSD (cash=$10,000.00) ...
 
-Running h1_liquidity from binance:USDT ...
-  SUCCESS: final=$10042.46 (profit=$42.46), path_len=3, time=102.649s
+[START] Running h1_liquidity from binance:USDT (cash=$10,000.00) ...
 
-Running h2_slippage from binance:USDT ...
-  SUCCESS: final=$10042.96 (profit=$42.96), path_len=3, time=60.405s
+[START] Running h2_slippage from binance:USDT (cash=$10,000.00) ...
 
-Running h4_chaincongestion_exchange_risk from binance:USDT ...
-  SUCCESS: final=$10041.45 (profit=$41.45), path_len=3, time=5.995s
+[START] Running h1_liquidity from kraken:USDT (cash=$10,000.00) ...
 
-Running h1_liquidity from kraken:USDT ...
-  SUCCESS: final=$10041.91 (profit=$41.91), path_len=3, time=105.035s
+[START] Running h4_chaincongestion_exchange_risk from binance:USDT (cash=$10,000.00) ...
 
-Running h2_slippage from kraken:USDT ...
-  SUCCESS: final=$10041.40 (profit=$41.40), path_len=3, time=59.485s
+[START] Running h2_slippage from kraken:USDT (cash=$10,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from binance:USDT: FAIL - No profitable path found (time=5.909s)
 
-Running h4_chaincongestion_exchange_risk from kraken:USDT ...
-  SUCCESS: final=$10041.40 (profit=$41.40), path_len=3, time=4.774s
+[START] Running h4_chaincongestion_exchange_risk from kraken:USDT (cash=$10,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from binance:BUSD: SUCCESS - final=$10001.49 (profit=$1.49), path_len=2, time=6.814s
 
-Running h3_parallel (random starts) ...
-  h3_parallel SUCCESS: final=$10041.45 (profit=$41.45), path_len=3, time=123.335s
+[START] Running simple_1hop from binance:BUSD (cash=$10,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from kraken:USDT: FAIL - No profitable path found (time=5.502s)
+
+[START] Running simple_2hop from binance:BUSD (cash=$10,000.00) ...
+[DONE] simple_1hop from binance:BUSD: FAIL - No profitable path found (time=5.835s)
+
+[START] Running simple_1hop from binance:USDT (cash=$10,000.00) ...
+[DONE] simple_1hop from binance:USDT: FAIL - No profitable path found (time=6.954s)
+
+[START] Running simple_2hop from binance:USDT (cash=$10,000.00) ...
+[DONE] simple_2hop from binance:BUSD: FAIL - No profitable path found (time=8.310s)
+
+[START] Running simple_1hop from kraken:USDT (cash=$10,000.00) ...
+[DONE] simple_2hop from binance:USDT: FAIL - No profitable path found (time=6.428s)
+
+[START] Running simple_2hop from kraken:USDT (cash=$10,000.00) ...
+[DONE] simple_1hop from kraken:USDT: FAIL - No profitable path found (time=7.050s)
+
+[START] Running h3_parallel from random_parallel (cash=$10,000.00) ...
+[DONE] simple_2hop from kraken:USDT: FAIL - No profitable path found (time=8.068s)
+[DONE] h2_slippage from binance:BUSD: SUCCESS - final=$10001.49 (profit=$1.49), path_len=2, time=73.927s
+[DONE] h2_slippage from kraken:USDT: FAIL - No profitable path found (time=74.477s)
+[DONE] h2_slippage from binance:USDT: FAIL - No profitable path found (time=77.172s)
+[DONE] h1_liquidity from binance:BUSD: SUCCESS - final=$10001.49 (profit=$1.49), path_len=2, time=90.577s
+[DONE] h1_liquidity from kraken:USDT: FAIL - No profitable path found (time=114.191s)
+[DONE] h1_liquidity from binance:USDT: FAIL - No profitable path found (time=119.939s)
+[DONE] h3_parallel from random_parallel: SUCCESS - final=$12085.47 (profit=$2085.47), path_len=2, time=115.623s
 
 ============================
 Order size: $100,000.00
 ============================
 
-Running h1_liquidity from binance:BUSD ...
-  SUCCESS: final=$100319.61 (profit=$319.61), path_len=4, time=86.156s
+[START] Running h1_liquidity from binance:BUSD (cash=$100,000.00) ...
 
-Running h2_slippage from binance:BUSD ...
-  SUCCESS: final=$100324.65 (profit=$324.65), path_len=4, time=55.495s
+[START] Running h2_slippage from binance:BUSD (cash=$100,000.00) ...
 
-Running h4_chaincongestion_exchange_risk from binance:BUSD ...
-  SUCCESS: final=$100329.69 (profit=$329.69), path_len=4, time=4.313s
+[START] Running h4_chaincongestion_exchange_risk from binance:BUSD (cash=$100,000.00) ...
 
-Running h1_liquidity from binance:USDT ...
-  SUCCESS: final=$100424.60 (profit=$424.60), path_len=3, time=110.749s
+[START] Running h1_liquidity from binance:USDT (cash=$100,000.00) ...
 
-Running h2_slippage from binance:USDT ...
-  SUCCESS: final=$100419.55 (profit=$419.55), path_len=3, time=68.234s
+[START] Running h2_slippage from binance:USDT (cash=$100,000.00) ...
 
-Running h4_chaincongestion_exchange_risk from binance:USDT ...
-  SUCCESS: final=$100414.51 (profit=$414.51), path_len=3, time=5.364s
+[START] Running h4_chaincongestion_exchange_risk from binance:USDT (cash=$100,000.00) ...
 
-Running h1_liquidity from kraken:USDT ...
-  SUCCESS: final=$100414.01 (profit=$414.01), path_len=3, time=104.177s
+[START] Running h2_slippage from kraken:USDT (cash=$100,000.00) ...
 
-Running h2_slippage from kraken:USDT ...
-  SUCCESS: final=$100419.05 (profit=$419.05), path_len=3, time=61.455s
+[START] Running h1_liquidity from kraken:USDT (cash=$100,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from binance:USDT: FAIL - No profitable path found (time=6.561s)
 
-Running h4_chaincongestion_exchange_risk from kraken:USDT ...
-  SUCCESS: final=$100414.01 (profit=$414.01), path_len=3, time=4.293s
+[START] Running h4_chaincongestion_exchange_risk from kraken:USDT (cash=$100,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from binance:BUSD: SUCCESS - final=$100014.91 (profit=$14.91), path_len=2, time=7.965s
 
-Running h3_parallel (random starts) ...
-  h3_parallel SUCCESS: final=$100414.51 (profit=$414.51), path_len=3, time=129.190s
+[START] Running simple_1hop from binance:BUSD (cash=$100,000.00) ...
+[DONE] h4_chaincongestion_exchange_risk from kraken:USDT: FAIL - No profitable path found (time=7.004s)
+
+[START] Running simple_2hop from binance:BUSD (cash=$100,000.00) ...
+[DONE] simple_1hop from binance:BUSD: FAIL - No profitable path found (time=6.054s)
+
+[START] Running simple_1hop from binance:USDT (cash=$100,000.00) ...
+[DONE] simple_1hop from binance:USDT: FAIL - No profitable path found (time=6.142s)
+
+[START] Running simple_2hop from binance:USDT (cash=$100,000.00) ...
+[DONE] simple_2hop from binance:BUSD: FAIL - No profitable path found (time=7.096s)
+
+[START] Running simple_1hop from kraken:USDT (cash=$100,000.00) ...
+[DONE] simple_2hop from binance:USDT: FAIL - No profitable path found (time=7.195s)
+
+[START] Running simple_2hop from kraken:USDT (cash=$100,000.00) ...
+[DONE] simple_1hop from kraken:USDT: FAIL - No profitable path found (time=7.751s)
+
+[START] Running h3_parallel from random_parallel (cash=$100,000.00) ...
+[DONE] simple_2hop from kraken:USDT: FAIL - No profitable path found (time=6.749s)
+[DONE] h2_slippage from binance:BUSD: SUCCESS - final=$100014.91 (profit=$14.91), path_len=2, time=73.057s
+[DONE] h2_slippage from kraken:USDT: FAIL - No profitable path found (time=74.145s)
+[DONE] h2_slippage from binance:USDT: FAIL - No profitable path found (time=76.894s)
+[DONE] h1_liquidity from binance:BUSD: SUCCESS - final=$100014.91 (profit=$14.91), path_len=2, time=104.695s
+[DONE] h1_liquidity from binance:USDT: FAIL - No profitable path found (time=132.643s)
+[DONE] h1_liquidity from kraken:USDT: FAIL - No profitable path found (time=135.179s)
+[DONE] h3_parallel from random_parallel: SUCCESS - final=$121594.50 (profit=$21594.50), path_len=2, time=129.169s
 
 
 ================ SUMMARY ================
-[OK] h=h1_liquidity                   start=binance:BUSD       cash=$ 1,000.00 final=$1003.20   profit=$3.20      len=  6 time=53.128s
-[OK] h=h2_slippage                    start=binance:BUSD       cash=$ 1,000.00 final=$1003.20   profit=$3.20      len=  4 time=55.930s
-[OK] h=h4_chaincongestion_exchange_risk start=binance:BUSD       cash=$ 1,000.00 final=$1003.20   profit=$3.20      len=  4 time= 4.176s
-[OK] h=h1_liquidity                   start=binance:USDT       cash=$ 1,000.00 final=$1004.15   profit=$4.15      len=  3 time=74.937s
-[OK] h=h2_slippage                    start=binance:USDT       cash=$ 1,000.00 final=$1004.15   profit=$4.15      len=  3 time=62.756s
-[OK] h=h4_chaincongestion_exchange_risk start=binance:USDT       cash=$ 1,000.00 final=$1004.15   profit=$4.15      len=  3 time= 5.439s
-[OK] h=h1_liquidity                   start=kraken:USDT        cash=$ 1,000.00 final=$1004.14   profit=$4.14      len=  3 time=80.685s
-[OK] h=h2_slippage                    start=kraken:USDT        cash=$ 1,000.00 final=$1004.14   profit=$4.14      len=  3 time=61.500s
-[OK] h=h4_chaincongestion_exchange_risk start=kraken:USDT        cash=$ 1,000.00 final=$1004.14   profit=$4.14      len=  3 time= 5.178s
-[OK] h=h3_parallel                    start=random_parallel    cash=$ 1,000.00 final=$1004.15   profit=$4.15      len=  3 time=92.559s
-[OK] h=h1_liquidity                   start=binance:BUSD       cash=$10,000.00 final=$10031.96  profit=$31.96     len=  5 time=80.060s
-[OK] h=h2_slippage                    start=binance:BUSD       cash=$10,000.00 final=$10032.47  profit=$32.47     len=  4 time=53.051s
-[OK] h=h4_chaincongestion_exchange_risk start=binance:BUSD       cash=$10,000.00 final=$10032.97  profit=$32.97     len=  4 time= 4.219s
-[OK] h=h1_liquidity                   start=binance:USDT       cash=$10,000.00 final=$10042.46  profit=$42.46     len=  3 time=102.649s
-[OK] h=h2_slippage                    start=binance:USDT       cash=$10,000.00 final=$10042.96  profit=$42.96     len=  3 time=60.405s
-[OK] h=h4_chaincongestion_exchange_risk start=binance:USDT       cash=$10,000.00 final=$10041.45  profit=$41.45     len=  3 time= 5.995s
-[OK] h=h1_liquidity                   start=kraken:USDT        cash=$10,000.00 final=$10041.91  profit=$41.91     len=  3 time=105.035s
-[OK] h=h2_slippage                    start=kraken:USDT        cash=$10,000.00 final=$10041.40  profit=$41.40     len=  3 time=59.485s
-[OK] h=h4_chaincongestion_exchange_risk start=kraken:USDT        cash=$10,000.00 final=$10041.40  profit=$41.40     len=  3 time= 4.774s
-[OK] h=h3_parallel                    start=random_parallel    cash=$10,000.00 final=$10041.45  profit=$41.45     len=  3 time=123.335s
-[OK] h=h1_liquidity                   start=binance:BUSD       cash=$100,000.00 final=$100319.61 profit=$319.61    len=  4 time=86.156s
-[OK] h=h2_slippage                    start=binance:BUSD       cash=$100,000.00 final=$100324.65 profit=$324.65    len=  4 time=55.495s
-[OK] h=h4_chaincongestion_exchange_risk start=binance:BUSD       cash=$100,000.00 final=$100329.69 profit=$329.69    len=  4 time= 4.313s
-[OK] h=h1_liquidity                   start=binance:USDT       cash=$100,000.00 final=$100424.60 profit=$424.60    len=  3 time=110.749s
-[OK] h=h2_slippage                    start=binance:USDT       cash=$100,000.00 final=$100419.55 profit=$419.55    len=  3 time=68.234s
-[OK] h=h4_chaincongestion_exchange_risk start=binance:USDT       cash=$100,000.00 final=$100414.51 profit=$414.51    len=  3 time= 5.364s
-[OK] h=h1_liquidity                   start=kraken:USDT        cash=$100,000.00 final=$100414.01 profit=$414.01    len=  3 time=104.177s
-[OK] h=h2_slippage                    start=kraken:USDT        cash=$100,000.00 final=$100419.05 profit=$419.05    len=  3 time=61.455s
-[OK] h=h4_chaincongestion_exchange_risk start=kraken:USDT        cash=$100,000.00 final=$100414.01 profit=$414.01    len=  3 time= 4.293s
-[OK] h=h3_parallel                    start=random_parallel    cash=$100,000.00 final=$100414.51 profit=$414.51    len=  3 time=129.190s
+[OK] h=h1_liquidity                   start=binance:BUSD       cash=$ 1,000.00 final=$1000.15   profit=$0.15      len=  2 time=85.299s
+[FAIL] h=h1_liquidity                   start=binance:USDT       cash=$ 1,000.00 final=N/A        profit=N/A        len=None time=106.316s
+[FAIL] h=h1_liquidity                   start=kraken:USDT        cash=$ 1,000.00 final=N/A        profit=N/A        len=None time=105.381s
+[OK] h=h2_slippage                    start=binance:BUSD       cash=$ 1,000.00 final=$1000.15   profit=$0.15      len=  2 time=73.716s
+[FAIL] h=h2_slippage                    start=binance:USDT       cash=$ 1,000.00 final=N/A        profit=N/A        len=None time=73.787s
+[FAIL] h=h2_slippage                    start=kraken:USDT        cash=$ 1,000.00 final=N/A        profit=N/A        len=None time=74.258s
+[OK] h=h3_parallel                    start=random_parallel    cash=$ 1,000.00 final=$1210.00   profit=$210.00    len=  2 time=108.574s
+[OK] h=h4_chaincongestion_exchange_risk start=binance:BUSD       cash=$ 1,000.00 final=$1000.15   profit=$0.15      len=  2 time= 6.212s
+[FAIL] h=h4_chaincongestion_exchange_risk start=binance:USDT       cash=$ 1,000.00 final=N/A        profit=N/A        len=None time= 5.927s
+[FAIL] h=h4_chaincongestion_exchange_risk start=kraken:USDT        cash=$ 1,000.00 final=N/A        profit=N/A        len=None time= 7.236s
+[FAIL] h=simple_1hop                    start=binance:BUSD       cash=$ 1,000.00 final=N/A        profit=N/A        len=None time= 7.533s
+[FAIL] h=simple_1hop                    start=binance:USDT       cash=$ 1,000.00 final=N/A        profit=N/A        len=None time= 8.219s
+[FAIL] h=simple_1hop                    start=kraken:USDT        cash=$ 1,000.00 final=N/A        profit=N/A        len=None time= 7.413s
+[FAIL] h=simple_2hop                    start=binance:BUSD       cash=$ 1,000.00 final=N/A        profit=N/A        len=None time= 8.344s
+[FAIL] h=simple_2hop                    start=binance:USDT       cash=$ 1,000.00 final=N/A        profit=N/A        len=None time= 7.100s
+[FAIL] h=simple_2hop                    start=kraken:USDT        cash=$ 1,000.00 final=N/A        profit=N/A        len=None time= 7.837s
+[OK] h=h1_liquidity                   start=binance:BUSD       cash=$10,000.00 final=$10001.49  profit=$1.49      len=  2 time=90.577s
+[FAIL] h=h1_liquidity                   start=binance:USDT       cash=$10,000.00 final=N/A        profit=N/A        len=None time=119.939s
+[FAIL] h=h1_liquidity                   start=kraken:USDT        cash=$10,000.00 final=N/A        profit=N/A        len=None time=114.191s
+[OK] h=h2_slippage                    start=binance:BUSD       cash=$10,000.00 final=$10001.49  profit=$1.49      len=  2 time=73.927s
+[FAIL] h=h2_slippage                    start=binance:USDT       cash=$10,000.00 final=N/A        profit=N/A        len=None time=77.172s
+[FAIL] h=h2_slippage                    start=kraken:USDT        cash=$10,000.00 final=N/A        profit=N/A        len=None time=74.477s
+[OK] h=h3_parallel                    start=random_parallel    cash=$10,000.00 final=$12085.47  profit=$2085.47   len=  2 time=115.623s
+[OK] h=h4_chaincongestion_exchange_risk start=binance:BUSD       cash=$10,000.00 final=$10001.49  profit=$1.49      len=  2 time= 6.814s
+[FAIL] h=h4_chaincongestion_exchange_risk start=binance:USDT       cash=$10,000.00 final=N/A        profit=N/A        len=None time= 5.909s
+[FAIL] h=h4_chaincongestion_exchange_risk start=kraken:USDT        cash=$10,000.00 final=N/A        profit=N/A        len=None time= 5.502s
+[FAIL] h=simple_1hop                    start=binance:BUSD       cash=$10,000.00 final=N/A        profit=N/A        len=None time= 5.835s
+[FAIL] h=simple_1hop                    start=binance:USDT       cash=$10,000.00 final=N/A        profit=N/A        len=None time= 6.954s
+[FAIL] h=simple_1hop                    start=kraken:USDT        cash=$10,000.00 final=N/A        profit=N/A        len=None time= 7.050s
+[FAIL] h=simple_2hop                    start=binance:BUSD       cash=$10,000.00 final=N/A        profit=N/A        len=None time= 8.310s
+[FAIL] h=simple_2hop                    start=binance:USDT       cash=$10,000.00 final=N/A        profit=N/A        len=None time= 6.428s
+[FAIL] h=simple_2hop                    start=kraken:USDT        cash=$10,000.00 final=N/A        profit=N/A        len=None time= 8.068s
+[OK] h=h1_liquidity                   start=binance:BUSD       cash=$100,000.00 final=$100014.91 profit=$14.91     len=  2 time=104.695s
+[FAIL] h=h1_liquidity                   start=binance:USDT       cash=$100,000.00 final=N/A        profit=N/A        len=None time=132.643s
+[FAIL] h=h1_liquidity                   start=kraken:USDT        cash=$100,000.00 final=N/A        profit=N/A        len=None time=135.179s
+[OK] h=h2_slippage                    start=binance:BUSD       cash=$100,000.00 final=$100014.91 profit=$14.91     len=  2 time=73.057s
+[FAIL] h=h2_slippage                    start=binance:USDT       cash=$100,000.00 final=N/A        profit=N/A        len=None time=76.894s
+[FAIL] h=h2_slippage                    start=kraken:USDT        cash=$100,000.00 final=N/A        profit=N/A        len=None time=74.145s
+[OK] h=h3_parallel                    start=random_parallel    cash=$100,000.00 final=$121594.50 profit=$21594.50  len=  2 time=129.169s
+[OK] h=h4_chaincongestion_exchange_risk start=binance:BUSD       cash=$100,000.00 final=$100014.91 profit=$14.91     len=  2 time= 7.965s
+[FAIL] h=h4_chaincongestion_exchange_risk start=binance:USDT       cash=$100,000.00 final=N/A        profit=N/A        len=None time= 6.561s
+[FAIL] h=h4_chaincongestion_exchange_risk start=kraken:USDT        cash=$100,000.00 final=N/A        profit=N/A        len=None time= 7.004s
+[FAIL] h=simple_1hop                    start=binance:BUSD       cash=$100,000.00 final=N/A        profit=N/A        len=None time= 6.054s
+[FAIL] h=simple_1hop                    start=binance:USDT       cash=$100,000.00 final=N/A        profit=N/A        len=None time= 6.142s
+[FAIL] h=simple_1hop                    start=kraken:USDT        cash=$100,000.00 final=N/A        profit=N/A        len=None time= 7.751s
+[FAIL] h=simple_2hop                    start=binance:BUSD       cash=$100,000.00 final=N/A        profit=N/A        len=None time= 7.096s
+[FAIL] h=simple_2hop                    start=binance:USDT       cash=$100,000.00 final=N/A        profit=N/A        len=None time= 7.195s
+[FAIL] h=simple_2hop                    start=kraken:USDT        cash=$100,000.00 final=N/A        profit=N/A        len=None time= 6.749s
+
+Completed: 2026-01-21 21:01:43
+
+Saved experiment log to: /Users/user/Desktop/CMPT417/Stablecoin-CrossExchange-Arbitrage/results/compare_heuristics_live.txt

--- a/scripts/baseline_algorithms.py
+++ b/scripts/baseline_algorithms.py
@@ -1,0 +1,606 @@
+"""
+Baseline algorithms for arbitrage path search.
+
+These algorithms serve as baselines for comparison against heuristic-guided A* search:
+- dijkstra_like: A* with h(n)=0 (no heuristic guidance)
+- greedy_best_first: Uses only heuristic, ignores path cost
+- breadth_first_search: Explores all paths up to depth limit
+- simple_1hop_arbitrage: Direct transfer cycle between two exchanges (same coin)
+- simple_2hop_arbitrage: Transfer A→B, trade on B, transfer back to A
+"""
+
+from __future__ import annotations
+
+import heapq
+import logging
+from collections import deque
+from dataclasses import dataclass
+from math import exp
+from typing import Any, Dict, List, Optional, Tuple
+
+from scripts.graph import build_graph
+from scripts.h1_vol import volume_heuristic_cost
+
+logger = logging.getLogger(__name__)
+
+NodeId = Tuple[str, str]
+
+
+@dataclass(frozen=True)
+class SearchState:
+    node: NodeId
+    depth: int
+    elapsed_sec: float
+
+
+@dataclass
+class PlanResult:
+    path: List[NodeId]
+    edges: List[Dict[str, Any]]
+    final_cash_usd: float
+    profit_usd: float
+
+
+def _final_cash_from_log_cost(initial_cash_usd: float, total_log_cost: float) -> float:
+    """Convert log-space cost to final cash amount."""
+    return initial_cash_usd * exp(-total_log_cost)
+
+
+def dijkstra_like_search(
+    start_node: NodeId,
+    liquid_cash_usd: float,
+    max_depth: int = 6,
+    max_time_sec: float = 1800.0,
+    min_profit_usd: float = 0.0,
+) -> Optional[PlanResult]:
+    """
+    A* search with h(n)=0 (Dijkstra-like, no heuristic guidance).
+    
+    This baseline uses only the actual path cost (g-score) without any
+    heuristic guidance, exploring paths in order of accumulated cost.
+    """
+    nodes, adj = build_graph()
+    
+    if start_node not in nodes:
+        raise ValueError(f"Start node {start_node} not present in graph.")
+    
+    start_state = SearchState(node=start_node, depth=0, elapsed_sec=0.0)
+    start_g = 0.0
+    start_h = 0.0  # No heuristic
+    start_f = start_g + start_h
+    
+    logger.info("Dijkstra-like search starting (h(n)=0)")
+    logger.info(f"Start node: {start_node}, liquid_cash: ${liquid_cash_usd:.2f}")
+    
+    frontier: List[Tuple[float, float, int, SearchState, List[NodeId], List[Dict[str, Any]]]] = []
+    counter = 0
+    heapq.heappush(frontier, (start_f, start_g, counter, start_state, [start_node], []))
+    counter += 1
+    
+    best_g_seen: Dict[Tuple[NodeId, int], float] = {(start_node, 0): start_g}
+    best_result: Optional[PlanResult] = None
+    
+    while frontier:
+        f_score, g_score, _, state, path_nodes, path_edges = heapq.heappop(frontier)
+        current_node = state.node
+        current_cash = _final_cash_from_log_cost(liquid_cash_usd, g_score)
+        
+        if state.depth > 0:
+            final_cash = current_cash
+            profit = final_cash - liquid_cash_usd
+            
+            if final_cash > liquid_cash_usd and profit >= min_profit_usd:
+                if best_result is None or final_cash > best_result.final_cash_usd:
+                    best_result = PlanResult(
+                        path=path_nodes.copy(),
+                        edges=path_edges.copy(),
+                        final_cash_usd=final_cash,
+                        profit_usd=profit,
+                    )
+        
+        if state.depth >= max_depth or state.elapsed_sec >= max_time_sec:
+            continue
+        
+        for edge in adj.get(current_node, []):
+            to_node: NodeId = edge["to"]
+            dt = float(edge.get("transfer_time_sec", 0.0))
+            new_elapsed = state.elapsed_sec + dt
+            if new_elapsed > max_time_sec:
+                continue
+            
+            edge_cost = float(edge.get("cost", 0.0))
+            new_g = g_score + edge_cost
+            new_depth = state.depth + 1
+            new_state = SearchState(node=to_node, depth=new_depth, elapsed_sec=new_elapsed)
+            
+            key = (to_node, new_depth)
+            if key in best_g_seen and new_g >= best_g_seen[key]:
+                continue
+            best_g_seen[key] = new_g
+            
+            # h(n) = 0 for Dijkstra-like
+            h = 0.0
+            f = new_g + h
+            
+            new_path_nodes = path_nodes + [to_node]
+            new_path_edges = path_edges + [edge]
+            
+            heapq.heappush(
+                frontier,
+                (f, new_g, counter, new_state, new_path_nodes, new_path_edges),
+            )
+            counter += 1
+    
+    if best_result is None:
+        logger.info("Dijkstra-like search: No profitable path found")
+        return None
+    
+    logger.info(
+        f"Dijkstra-like search completed: "
+        f"Final profit=${best_result.profit_usd:.2f}, "
+        f"path_length={len(best_result.path)}"
+    )
+    return best_result
+
+
+def greedy_best_first_search(
+    start_node: NodeId,
+    liquid_cash_usd: float,
+    max_depth: int = 6,
+    max_time_sec: float = 1800.0,
+    min_profit_usd: float = 0.0,
+    heuristic: str = "h1_liquidity",
+) -> Optional[PlanResult]:
+    """
+    Greedy Best-First Search: uses only heuristic, ignores path cost.
+    
+    This baseline prioritizes nodes with the lowest heuristic value,
+    completely ignoring the actual path cost (g-score).
+    """
+    nodes, adj = build_graph()
+    
+    if start_node not in nodes:
+        raise ValueError(f"Start node {start_node} not present in graph.")
+    
+    start_state = SearchState(node=start_node, depth=0, elapsed_sec=0.0)
+    
+    logger.info(f"Greedy Best-First search starting with heuristic: {heuristic}")
+    logger.info(f"Start node: {start_node}, liquid_cash: ${liquid_cash_usd:.2f}")
+    
+    # Compute initial heuristic
+    if heuristic == "h1_liquidity":
+        start_h = volume_heuristic_cost(
+            exchange_name=start_node[0],
+            coin=start_node[1],
+            order_notional_usd=liquid_cash_usd,
+            remaining_time_sec=max_time_sec,
+        )
+    else:
+        raise ValueError(f"Unknown heuristic: {heuristic}")
+    
+    # Use only heuristic (h) for priority, ignore g
+    frontier: List[Tuple[float, float, int, SearchState, List[NodeId], List[Dict[str, Any]]]] = []
+    counter = 0
+    heapq.heappush(frontier, (start_h, 0.0, counter, start_state, [start_node], []))
+    counter += 1
+    
+    visited: Dict[Tuple[NodeId, int], float] = {(start_node, 0): 0.0}
+    best_result: Optional[PlanResult] = None
+    
+    while frontier:
+        h_score, g_score, _, state, path_nodes, path_edges = heapq.heappop(frontier)
+        current_node = state.node
+        current_cash = _final_cash_from_log_cost(liquid_cash_usd, g_score)
+        
+        if state.depth > 0:
+            final_cash = current_cash
+            profit = final_cash - liquid_cash_usd
+            
+            if final_cash > liquid_cash_usd and profit >= min_profit_usd:
+                if best_result is None or final_cash > best_result.final_cash_usd:
+                    best_result = PlanResult(
+                        path=path_nodes.copy(),
+                        edges=path_edges.copy(),
+                        final_cash_usd=final_cash,
+                        profit_usd=profit,
+                    )
+        
+        if state.depth >= max_depth or state.elapsed_sec >= max_time_sec:
+            continue
+        
+        for edge in adj.get(current_node, []):
+            to_node: NodeId = edge["to"]
+            dt = float(edge.get("transfer_time_sec", 0.0))
+            new_elapsed = state.elapsed_sec + dt
+            if new_elapsed > max_time_sec:
+                continue
+            
+            edge_cost = float(edge.get("cost", 0.0))
+            new_g = g_score + edge_cost
+            new_depth = state.depth + 1
+            new_state = SearchState(node=to_node, depth=new_depth, elapsed_sec=new_elapsed)
+            
+            key = (to_node, new_depth)
+            if key in visited:
+                continue  # Greedy: don't revisit
+            visited[key] = new_g
+            
+            # Compute heuristic at neighbor
+            remaining_time = max_time_sec - new_elapsed
+            new_cash = _final_cash_from_log_cost(liquid_cash_usd, new_g)
+            
+            if heuristic == "h1_liquidity":
+                h = volume_heuristic_cost(
+                    exchange_name=to_node[0],
+                    coin=to_node[1],
+                    order_notional_usd=new_cash,
+                    remaining_time_sec=remaining_time,
+                )
+            else:
+                raise ValueError(f"Unknown heuristic: {heuristic}")
+            
+            # Use only h for priority (greedy)
+            new_path_nodes = path_nodes + [to_node]
+            new_path_edges = path_edges + [edge]
+            
+            heapq.heappush(
+                frontier,
+                (h, new_g, counter, new_state, new_path_nodes, new_path_edges),
+            )
+            counter += 1
+    
+    if best_result is None:
+        logger.info("Greedy Best-First search: No profitable path found")
+        return None
+    
+    logger.info(
+        f"Greedy Best-First search completed: "
+        f"Final profit=${best_result.profit_usd:.2f}, "
+        f"path_length={len(best_result.path)}"
+    )
+    return best_result
+
+
+def breadth_first_search(
+    start_node: NodeId,
+    liquid_cash_usd: float,
+    max_depth: int = 6,
+    max_time_sec: float = 1800.0,
+    min_profit_usd: float = 0.0,
+) -> Optional[PlanResult]:
+    """
+    Breadth-First Search: explores all paths up to depth limit.
+    
+    This baseline explores nodes level by level, finding the first
+    profitable path at the shallowest depth.
+    """
+    nodes, adj = build_graph()
+    
+    if start_node not in nodes:
+        raise ValueError(f"Start node {start_node} not present in graph.")
+    
+    logger.info("Breadth-First search starting")
+    logger.info(f"Start node: {start_node}, liquid_cash: ${liquid_cash_usd:.2f}")
+    
+    start_state = SearchState(node=start_node, depth=0, elapsed_sec=0.0)
+    queue: deque = deque([(0.0, start_state, [start_node], [])])
+    visited: Dict[Tuple[NodeId, int], float] = {(start_node, 0): 0.0}
+    best_result: Optional[PlanResult] = None
+    
+    while queue:
+        g_score, state, path_nodes, path_edges = queue.popleft()
+        current_node = state.node
+        current_cash = _final_cash_from_log_cost(liquid_cash_usd, g_score)
+        
+        if state.depth > 0:
+            final_cash = current_cash
+            profit = final_cash - liquid_cash_usd
+            
+            if final_cash > liquid_cash_usd and profit >= min_profit_usd:
+                if best_result is None or final_cash > best_result.final_cash_usd:
+                    best_result = PlanResult(
+                        path=path_nodes.copy(),
+                        edges=path_edges.copy(),
+                        final_cash_usd=final_cash,
+                        profit_usd=profit,
+                    )
+        
+        if state.depth >= max_depth or state.elapsed_sec >= max_time_sec:
+            continue
+        
+        for edge in adj.get(current_node, []):
+            to_node: NodeId = edge["to"]
+            dt = float(edge.get("transfer_time_sec", 0.0))
+            new_elapsed = state.elapsed_sec + dt
+            if new_elapsed > max_time_sec:
+                continue
+            
+            edge_cost = float(edge.get("cost", 0.0))
+            new_g = g_score + edge_cost
+            new_depth = state.depth + 1
+            new_state = SearchState(node=to_node, depth=new_depth, elapsed_sec=new_elapsed)
+            
+            key = (to_node, new_depth)
+            if key in visited:
+                continue
+            visited[key] = new_g
+            
+            new_path_nodes = path_nodes + [to_node]
+            new_path_edges = path_edges + [edge]
+            
+            queue.append((new_g, new_state, new_path_nodes, new_path_edges))
+    
+    if best_result is None:
+        logger.info("Breadth-First search: No profitable path found")
+        return None
+    
+    logger.info(
+        f"Breadth-First search completed: "
+        f"Final profit=${best_result.profit_usd:.2f}, "
+        f"path_length={len(best_result.path)}"
+    )
+    return best_result
+
+
+def simple_1hop_arbitrage(
+    start_node: NodeId,
+    liquid_cash_usd: float,
+    max_time_sec: float = 1800.0,
+    min_profit_usd: float = 0.0,
+) -> Optional[PlanResult]:
+    """
+    Simple 1-hop baseline: Direct transfer cycle between two exchanges for the same coin.
+    
+    This represents the naive strategy of finding the best direct price difference
+    between two exchanges by transferring from exchange A to exchange B and back.
+    
+    Algorithm:
+    1. For each exchange pair that supports the same coin as start_node
+    2. Find transfer edge A→B (same coin)
+    3. Find transfer edge B→A (same coin)
+    4. Calculate total cost and return most profitable cycle
+    """
+    nodes, adj = build_graph()
+    
+    if start_node not in nodes:
+        raise ValueError(f"Start node {start_node} not present in graph.")
+    
+    start_exchange, start_coin = start_node
+    
+    logger.info("Simple 1-hop arbitrage starting")
+    logger.info(f"Start node: {start_node}, liquid_cash: ${liquid_cash_usd:.2f}")
+    
+    best_result: Optional[PlanResult] = None
+    
+    # Find all exchanges that support the same coin
+    exchanges_with_coin = [
+        (ex, coin) for (ex, coin) in nodes.keys()
+        if coin == start_coin and ex != start_exchange
+    ]
+    
+    # Try each exchange pair
+    for target_exchange, _ in exchanges_with_coin:
+        target_node: NodeId = (target_exchange, start_coin)
+        
+        # Find transfer edge from start to target
+        transfer_out_edge = None
+        for edge in adj.get(start_node, []):
+            if (edge.get("kind") == "transfer" and 
+                edge["to"] == target_node and
+                edge.get("coin_from") == start_coin):
+                transfer_out_edge = edge
+                break
+        
+        if transfer_out_edge is None:
+            continue
+        
+        # Find transfer edge from target back to start
+        transfer_back_edge = None
+        for edge in adj.get(target_node, []):
+            if (edge.get("kind") == "transfer" and
+                edge["to"] == start_node and
+                edge.get("coin_from") == start_coin):
+                transfer_back_edge = edge
+                break
+        
+        if transfer_back_edge is None:
+            continue
+        
+        # Calculate total cost
+        total_cost = transfer_out_edge["cost"] + transfer_back_edge["cost"]
+        total_time = (transfer_out_edge.get("transfer_time_sec", 0.0) + 
+                     transfer_back_edge.get("transfer_time_sec", 0.0))
+        
+        if total_time > max_time_sec:
+            continue
+        
+        final_cash = _final_cash_from_log_cost(liquid_cash_usd, total_cost)
+        profit = final_cash - liquid_cash_usd
+        
+        if final_cash > liquid_cash_usd and profit >= min_profit_usd:
+            if best_result is None or final_cash > best_result.final_cash_usd:
+                best_result = PlanResult(
+                    path=[start_node, target_node, start_node],
+                    edges=[transfer_out_edge, transfer_back_edge],
+                    final_cash_usd=final_cash,
+                    profit_usd=profit,
+                )
+    
+    if best_result is None:
+        logger.info("Simple 1-hop arbitrage: No profitable path found")
+        return None
+    
+    logger.info(
+        f"Simple 1-hop arbitrage completed: "
+        f"Final profit=${best_result.profit_usd:.2f}, "
+        f"path_length={len(best_result.path)}"
+    )
+    return best_result
+
+
+def simple_2hop_arbitrage(
+    start_node: NodeId,
+    liquid_cash_usd: float,
+    max_time_sec: float = 1800.0,
+    min_profit_usd: float = 0.0,
+) -> Optional[PlanResult]:
+    """
+    Simple 2-hop baseline: Transfer A→B, trade on B, transfer back to A.
+    
+    This represents a naive 2-exchange arbitrage strategy:
+    1. Transfer from exchange A to exchange B (same coin)
+    2. Trade to a different coin on exchange B
+    3. Transfer back to exchange A (with the new coin, if supported)
+    
+    If exchange A doesn't support the new coin, we trade back to original coin
+    on exchange B before transferring (making it effectively 3 hops, but still
+    a simple strategy).
+    """
+    nodes, adj = build_graph()
+    
+    if start_node not in nodes:
+        raise ValueError(f"Start node {start_node} not present in graph.")
+    
+    start_exchange, start_coin = start_node
+    
+    logger.info("Simple 2-hop arbitrage starting")
+    logger.info(f"Start node: {start_node}, liquid_cash: ${liquid_cash_usd:.2f}")
+    
+    best_result: Optional[PlanResult] = None
+    
+    # Find all exchanges that support the same coin
+    exchanges_with_coin = [
+        (ex, coin) for (ex, coin) in nodes.keys()
+        if coin == start_coin and ex != start_exchange
+    ]
+    
+    # Try each target exchange
+    for target_exchange, _ in exchanges_with_coin:
+        target_node: NodeId = (target_exchange, start_coin)
+        
+        # Find transfer edge from start to target
+        transfer_out_edge = None
+        for edge in adj.get(start_node, []):
+            if (edge.get("kind") == "transfer" and 
+                edge["to"] == target_node and
+                edge.get("coin_from") == start_coin):
+                transfer_out_edge = edge
+                break
+        
+        if transfer_out_edge is None:
+            continue
+        
+        # Find all coins available on target exchange
+        coins_on_target = [
+            coin for (ex, coin) in nodes.keys()
+            if ex == target_exchange and coin != start_coin
+        ]
+        
+        # Try each coin on target exchange
+        for target_coin in coins_on_target:
+            target_coin_node: NodeId = (target_exchange, target_coin)
+            
+            # Find trade edge on target exchange (start_coin -> target_coin)
+            trade_edge = None
+            for edge in adj.get(target_node, []):
+                if (edge.get("kind") == "trade" and
+                    edge["to"] == target_coin_node and
+                    edge.get("exchange") == target_exchange):
+                    trade_edge = edge
+                    break
+            
+            if trade_edge is None:
+                continue
+            
+            # Calculate cost so far
+            cost_so_far = transfer_out_edge["cost"] + trade_edge["cost"]
+            time_so_far = (transfer_out_edge.get("transfer_time_sec", 0.0) +
+                          trade_edge.get("transfer_time_sec", 0.0))
+            
+            # Try to transfer back to start exchange with target_coin
+            final_node_with_new_coin: NodeId = (start_exchange, target_coin)
+            transfer_back_edge = None
+            
+            if final_node_with_new_coin in nodes:
+                # Start exchange supports the new coin - direct transfer back
+                for edge in adj.get(target_coin_node, []):
+                    if (edge.get("kind") == "transfer" and
+                        edge["to"] == final_node_with_new_coin and
+                        edge.get("coin_from") == target_coin):
+                        transfer_back_edge = edge
+                        break
+                
+                if transfer_back_edge:
+                    total_cost = cost_so_far + transfer_back_edge["cost"]
+                    total_time = time_so_far + transfer_back_edge.get("transfer_time_sec", 0.0)
+                    
+                    if total_time <= max_time_sec:
+                        final_cash = _final_cash_from_log_cost(liquid_cash_usd, total_cost)
+                        profit = final_cash - liquid_cash_usd
+                        
+                        if final_cash > liquid_cash_usd and profit >= min_profit_usd:
+                            if best_result is None or final_cash > best_result.final_cash_usd:
+                                best_result = PlanResult(
+                                    path=[start_node, target_node, target_coin_node, final_node_with_new_coin],
+                                    edges=[transfer_out_edge, trade_edge, transfer_back_edge],
+                                    final_cash_usd=final_cash,
+                                    profit_usd=profit,
+                                )
+            
+            # If direct transfer back not possible, trade back to start_coin then transfer
+            if transfer_back_edge is None:
+                # Find trade edge back to start_coin on target exchange
+                trade_back_edge = None
+                for edge in adj.get(target_coin_node, []):
+                    if (edge.get("kind") == "trade" and
+                        edge["to"] == target_node and
+                        edge.get("exchange") == target_exchange):
+                        trade_back_edge = edge
+                        break
+                
+                if trade_back_edge is None:
+                    continue
+                
+                # Find transfer back to start with original coin
+                transfer_back_original = None
+                for edge in adj.get(target_node, []):
+                    if (edge.get("kind") == "transfer" and
+                        edge["to"] == start_node and
+                        edge.get("coin_from") == start_coin):
+                        transfer_back_original = edge
+                        break
+                
+                if transfer_back_original is None:
+                    continue
+                
+                total_cost = cost_so_far + trade_back_edge["cost"] + transfer_back_original["cost"]
+                total_time = (time_so_far + 
+                            trade_back_edge.get("transfer_time_sec", 0.0) +
+                            transfer_back_original.get("transfer_time_sec", 0.0))
+                
+                if total_time <= max_time_sec:
+                    final_cash = _final_cash_from_log_cost(liquid_cash_usd, total_cost)
+                    profit = final_cash - liquid_cash_usd
+                    
+                    if final_cash > liquid_cash_usd and profit >= min_profit_usd:
+                        if best_result is None or final_cash > best_result.final_cash_usd:
+                            best_result = PlanResult(
+                                path=[start_node, target_node, target_coin_node, target_node, start_node],
+                                edges=[transfer_out_edge, trade_edge, trade_back_edge, transfer_back_original],
+                                final_cash_usd=final_cash,
+                                profit_usd=profit,
+                            )
+    
+    if best_result is None:
+        logger.info("Simple 2-hop arbitrage: No profitable path found")
+        return None
+    
+    logger.info(
+        f"Simple 2-hop arbitrage completed: "
+        f"Final profit=${best_result.profit_usd:.2f}, "
+        f"path_length={len(best_result.path)}"
+    )
+    return best_result
+
+
+


### PR DESCRIPTION
- Implement simple_1hop_arbitrage and simple_2hop_arbitrage baselines
- Add parallel execution to compare_heuristics_live.py with incremental file writing
- Integrate baselines into experimental framework
- Add latest comparison results

Addresses issue #4: Baseline Results Generation