### PR TITLE
Fix: Bellman-Ford misses Hamiltonian negative cycles

### DIFF
--- a/scripts/bellman_ford_arbitrage.py
+++ b/scripts/bellman_ford_arbitrage.py
@@ -102,7 +102,9 @@ def detect_negative_cycles(
             # If we can still relax, there's a negative cycle
             if dist[u] + cost < dist[v]:
                 # Trace back to find the cycle
-                cycle = _extract_cycle(v, pred, n)
+                # Use 2*n steps: predecessor chains in cycles can revisit nodes,
+                # and n steps is insufficient for Hamiltonian cycles (cycle len == n)
+                cycle = _extract_cycle(v, pred, 2 * n)
                 if cycle and tuple(cycle) not in visited_cycles:
                     visited_cycles.add(tuple(cycle))
                     negative_cycles.append(cycle)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,913 @@
+"""
+Regression & benchmark tests for core algorithms.
+
+Covers:
+  - Signal generators (OU params, z-score, spread computation)
+  - Execution cost calculations
+  - Simulator (simulate_fast) with deterministic benchmarks
+  - Bellman-Ford negative cycle detection
+  - Fee lookups and price normalization
+  - PaperTrader signal/trade flow
+  - Edge cases (empty data, degenerate inputs, boundary conditions)
+
+Run:
+    pytest tests/test_core.py -v
+"""
+
+import math
+import time
+import numpy as np
+import pytest
+import sys
+import os
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ======================================================================
+# Signal generators  (paper_trader.py)
+# ======================================================================
+
+from experiments.paper_trader import (
+    estimate_ou_params,
+    compute_zscore_rolling,
+    compute_ou_zscore,
+    compute_spread_bps,
+    compute_entry_cost,
+    Config,
+    Tick,
+    PaperTrader,
+    State,
+)
+
+
+class TestEstimateOUParams:
+    """Regression tests for OU parameter estimation."""
+
+    def test_synthetic_ou_process(self):
+        """An OU process with known parameters should recover them approximately."""
+        np.random.seed(42)
+        theta_true, mu_true, sigma_true = 0.5, 0.0, 1.0
+        n = 500
+        dt = 1.0
+        x = np.zeros(n)
+        for i in range(1, n):
+            x[i] = x[i-1] + theta_true * (mu_true - x[i-1]) * dt + sigma_true * np.random.randn() * np.sqrt(dt)
+
+        theta, mu, sigma = estimate_ou_params(x, dt)
+        assert theta is not None
+        assert 0.1 < theta < 2.0, f"theta={theta} out of expected range"
+        assert -1.0 < mu < 1.0, f"mu={mu} out of expected range"
+        assert 0.3 < sigma < 3.0, f"sigma={sigma} out of expected range"
+
+    def test_too_few_points_returns_none(self):
+        """Less than 20 data points should return None."""
+        for n in [0, 1, 5, 10, 19]:
+            result = estimate_ou_params(np.random.randn(max(n, 1)))
+            assert result == (None, None, None), f"n={n} should return None"
+
+    def test_exactly_20_points_works(self):
+        """20 points is the minimum; should not crash."""
+        np.random.seed(0)
+        x = np.cumsum(np.random.randn(20))  # random walk, may or may not be MR
+        result = estimate_ou_params(x)
+        # May return None (not mean-reverting) or valid params, but should not crash
+        assert len(result) == 3
+
+    def test_constant_spread_returns_none(self):
+        """Constant spread has sigma=0, should return None."""
+        x = np.ones(100) * 5.0
+        assert estimate_ou_params(x) == (None, None, None)
+
+    def test_trending_series_returns_none(self):
+        """A monotonically increasing series is not mean-reverting (b >= 0)."""
+        x = np.arange(100, dtype=float)
+        result = estimate_ou_params(x)
+        assert result == (None, None, None)
+
+    def test_theta_is_positive(self):
+        """OU theta should be positive (mean-reverting speed)."""
+        np.random.seed(99)
+        x = np.zeros(200)
+        for i in range(1, 200):
+            x[i] = x[i-1] * 0.9 + np.random.randn() * 0.5
+        theta, mu, sigma = estimate_ou_params(x)
+        if theta is not None:
+            assert theta > 0
+
+
+class TestComputeZscoreRolling:
+    """Regression tests for rolling z-score computation."""
+
+    def test_known_zscore(self):
+        """Hand-computed z-score for simple data."""
+        # Window of [1, 2, 3, 4, 5], mean=3, std=sqrt(2)
+        spreads = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        z = compute_zscore_rolling(spreads, window=5)
+        expected = (5.0 - 3.0) / np.std([1, 2, 3, 4, 5])
+        assert z == pytest.approx(expected, abs=1e-6)
+
+    def test_mean_value_has_zero_zscore(self):
+        """If last value equals the window mean, z-score should be ~0."""
+        spreads = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 3.0])  # last=3=mean
+        z = compute_zscore_rolling(spreads, window=5)
+        # Window is [2,3,4,5,3], mean=3.4, z = (3-3.4)/std
+        # Not exactly zero because window shifts. Test with symmetric data:
+        spreads2 = np.array([-1.0, 1.0, -1.0, 1.0, 0.0])
+        z2 = compute_zscore_rolling(spreads2, window=5)
+        assert z2 == pytest.approx(0.0, abs=1e-6)
+
+    def test_too_few_points_returns_none(self):
+        """Fewer points than window should return None."""
+        assert compute_zscore_rolling(np.array([1.0, 2.0]), window=5) is None
+        assert compute_zscore_rolling(np.array([1.0]), window=2) is None
+        assert compute_zscore_rolling(np.array([]), window=1) is None
+
+    def test_constant_window_returns_none(self):
+        """Zero std (all same values) should return None."""
+        spreads = np.array([3.0, 3.0, 3.0, 3.0, 3.0])
+        assert compute_zscore_rolling(spreads, window=5) is None
+
+    def test_window_equals_length(self):
+        """Edge case: window equals array length."""
+        spreads = np.array([1.0, 3.0, 5.0])
+        z = compute_zscore_rolling(spreads, window=3)
+        assert z is not None
+        expected = (5.0 - 3.0) / np.std([1, 3, 5])
+        assert z == pytest.approx(expected, abs=1e-6)
+
+    def test_large_outlier_produces_high_zscore(self):
+        """An extreme outlier should produce a large z-score."""
+        spreads = np.array([0.0] * 99 + [100.0])
+        z = compute_zscore_rolling(spreads, window=100)
+        assert z is not None
+        assert abs(z) > 5.0
+
+
+class TestComputeOUZscore:
+    """Tests for OU-based z-score computation."""
+
+    def test_returns_none_for_short_series(self):
+        assert compute_ou_zscore(np.array([1.0, 2.0]), window=5) is None
+
+    def test_returns_none_for_non_mean_reverting(self):
+        """Trending data should return None (OU estimation fails)."""
+        x = np.arange(100, dtype=float)
+        assert compute_ou_zscore(x, window=100) is None
+
+    def test_returns_value_for_ou_process(self):
+        """Synthetic OU data should produce a valid z-score."""
+        np.random.seed(42)
+        x = np.zeros(200)
+        for i in range(1, 200):
+            x[i] = x[i-1] * 0.9 + np.random.randn() * 0.5
+        z = compute_ou_zscore(x, window=100)
+        # May be None if the last 100 points happen to not be MR,
+        # but with seed=42 it should work
+        if z is not None:
+            assert isinstance(z, float)
+            assert not np.isnan(z)
+
+
+# ======================================================================
+# Spread & cost calculations
+# ======================================================================
+
+class TestComputeSpreadBps:
+    """Regression tests for spread computation."""
+
+    def test_equal_prices_zero_spread(self):
+        assert compute_spread_bps(1.0, 1.0) == 0.0
+
+    def test_positive_spread(self):
+        # B is 1% higher than A: (1.01 - 1.0) / 1.0 * 10000 = 100 bps
+        assert compute_spread_bps(1.0, 1.01) == pytest.approx(100.0, abs=0.01)
+
+    def test_negative_spread(self):
+        # B is 1% lower than A: (0.99 - 1.0) / 1.0 * 10000 = -100 bps
+        assert compute_spread_bps(1.0, 0.99) == pytest.approx(-100.0, abs=0.01)
+
+    def test_zero_mid_a_returns_zero(self):
+        """Division by zero protection."""
+        assert compute_spread_bps(0.0, 1.0) == 0.0
+        assert compute_spread_bps(-1.0, 1.0) == 0.0
+
+    def test_small_prices(self):
+        """PEPE-like prices (0.00001 range) should still work."""
+        a = 0.00001234
+        b = 0.00001256
+        expected = (b - a) / a * 10_000
+        assert compute_spread_bps(a, b) == pytest.approx(expected, rel=1e-6)
+
+    def test_symmetry_property(self):
+        """spread(A,B) ≈ -spread(B,A) for close prices."""
+        a, b = 1.00, 1.01
+        s1 = compute_spread_bps(a, b)
+        s2 = compute_spread_bps(b, a)
+        # Not exactly symmetric but approximately
+        assert s1 > 0
+        assert s2 < 0
+
+
+class TestComputeEntryCost:
+    """Regression tests for execution cost calculation."""
+
+    def test_known_exchange_pair(self):
+        """Binance + Crypto.com: 10 + 7.5 = 17.5 bps fees."""
+        cfg = Config(exchange_a="binance", exchange_b="cryptocom", slippage_bps=2.0)
+        fee_bps, slip_bps = compute_entry_cost(cfg)
+        expected_fee = (0.0010 + 0.00075) * 10_000  # 17.5 bps
+        assert fee_bps == pytest.approx(expected_fee, abs=0.01)
+        assert slip_bps == pytest.approx(4.0, abs=0.01)  # 2 * 2.0
+
+    def test_unknown_exchange_defaults(self):
+        """Unknown exchange should default to 0.001 (10 bps)."""
+        cfg = Config(exchange_a="unknown_exchange", exchange_b="binance", slippage_bps=0)
+        fee_bps, slip_bps = compute_entry_cost(cfg)
+        # unknown=10bps + binance=10bps = 20 bps
+        assert fee_bps == pytest.approx(20.0, abs=0.01)
+
+    def test_zero_slippage(self):
+        cfg = Config(exchange_a="binance", exchange_b="binance", slippage_bps=0)
+        _, slip_bps = compute_entry_cost(cfg)
+        assert slip_bps == 0.0
+
+    def test_mexc_zero_maker_still_has_taker(self):
+        """MEXC has 0% maker but 0.05% taker — taker should be used."""
+        cfg = Config(exchange_a="mexc", exchange_b="mexc", slippage_bps=0)
+        fee_bps, _ = compute_entry_cost(cfg)
+        assert fee_bps == pytest.approx(10.0, abs=0.01)  # 5 + 5 bps
+
+
+# ======================================================================
+# simulate_fast (optimize_v2.py) — deterministic benchmarks
+# ======================================================================
+
+from experiments.optimize_v2 import simulate_fast, precompute_rolling
+
+
+class TestSimulateFast:
+    """Deterministic regression benchmarks for the core simulator."""
+
+    def _make_mean_reverting_spread(self, n=500, seed=42):
+        """Generate a synthetic mean-reverting spread for testing."""
+        np.random.seed(seed)
+        x = np.zeros(n)
+        for i in range(1, n):
+            x[i] = x[i-1] * 0.85 + np.random.randn() * 10.0
+        return x
+
+    def test_no_trades_below_threshold(self):
+        """Flat spread with high entry_z should produce no trades."""
+        spread = np.zeros(200)
+        z = np.zeros(200)
+        std = np.ones(200) * 5.0
+        result = simulate_fast(spread, z, std, cost_bps=10, entry_z=5.0,
+                               exit_z=0.0, vol_mult=0, cooldown=0, max_hold=0)
+        assert result is None  # < 5 trades
+
+    def test_known_single_trade(self):
+        """Manually construct spread that triggers exactly one entry+exit."""
+        n = 50
+        spread = np.zeros(n)
+        z = np.zeros(n)
+        std = np.ones(n) * 100.0  # high vol, always passes filter
+
+        # Create one clear short_spread signal: z goes to +3 then back to 0
+        z[10] = 3.0  # entry
+        spread[10] = 50.0
+        z[20] = -0.1  # exit (below exit_z=0)
+        spread[20] = 30.0
+
+        result = simulate_fast(spread, z, std, cost_bps=5.0, entry_z=2.0,
+                               exit_z=0.0, vol_mult=0, cooldown=0, max_hold=0)
+        # Only 1 trade, need >= 5. So should return None.
+        assert result is None
+
+    def test_benchmark_mean_reverting(self):
+        """Benchmark: synthetic MR spread should be profitable with optimal params."""
+        spread = self._make_mean_reverting_spread(1000)
+        rolling = precompute_rolling(spread, [60])
+        z = rolling[60]["z"]
+        std = rolling[60]["std"]
+
+        result = simulate_fast(spread, z, std, cost_bps=10.0, entry_z=2.0,
+                               exit_z=0.0, vol_mult=0, cooldown=0, max_hold=60)
+        assert result is not None
+        assert result["trades"] >= 5
+        # With strong MR and reasonable cost, should be profitable
+        assert result["avg_net"] > 0, f"Expected profitable, got avg_net={result['avg_net']}"
+        # Record benchmark values for regression detection
+        assert result["win_rate"] > 40, f"Win rate {result['win_rate']} too low"
+
+    def test_benchmark_deterministic_values(self):
+        """Pin exact values with fixed seed to detect algorithm changes."""
+        spread = self._make_mean_reverting_spread(500, seed=123)
+        rolling = precompute_rolling(spread, [30])
+        z = rolling[30]["z"]
+        std = rolling[30]["std"]
+
+        result = simulate_fast(spread, z, std, cost_bps=8.0, entry_z=1.5,
+                               exit_z=0.3, vol_mult=0, cooldown=0, max_hold=30)
+        if result is not None:
+            # Store trade count for regression detection — any change means algo changed
+            assert isinstance(result["trades"], int)
+            assert isinstance(result["avg_net"], float)
+            assert isinstance(result["sharpe"], float)
+            assert result["max_dd"] >= 0
+            assert 0 <= result["win_rate"] <= 100
+            assert 0 <= result["timeout_pct"] <= 100
+
+    def test_vol_filter_blocks_low_vol(self):
+        """Vol filter should prevent entries when std < vol_mult * cost."""
+        spread = self._make_mean_reverting_spread(500)
+        rolling = precompute_rolling(spread, [30])
+        z = rolling[30]["z"]
+        std = rolling[30]["std"]
+
+        # Set vol_mult very high so vol_threshold = 100 * 10 = 1000 bps
+        result = simulate_fast(spread, z, std, cost_bps=10.0, entry_z=2.0,
+                               exit_z=0.0, vol_mult=100.0, cooldown=0, max_hold=60)
+        assert result is None  # No trades should pass the filter
+
+    def test_cooldown_reduces_trade_count(self):
+        """Higher cooldown should produce fewer or equal trades."""
+        spread = self._make_mean_reverting_spread(1000)
+        rolling = precompute_rolling(spread, [30])
+        z = rolling[30]["z"]
+        std = rolling[30]["std"]
+
+        r0 = simulate_fast(spread, z, std, cost_bps=8.0, entry_z=1.5,
+                           exit_z=0.3, vol_mult=0, cooldown=0, max_hold=60)
+        r50 = simulate_fast(spread, z, std, cost_bps=8.0, entry_z=1.5,
+                            exit_z=0.3, vol_mult=0, cooldown=50, max_hold=60)
+
+        if r0 is not None and r50 is not None:
+            assert r50["trades"] <= r0["trades"]
+
+    def test_higher_entry_z_fewer_trades(self):
+        """Stricter entry threshold should produce fewer trades."""
+        spread = self._make_mean_reverting_spread(1000)
+        rolling = precompute_rolling(spread, [30])
+        z = rolling[30]["z"]
+        std = rolling[30]["std"]
+
+        r_low = simulate_fast(spread, z, std, cost_bps=8.0, entry_z=1.0,
+                              exit_z=0.0, vol_mult=0, cooldown=0, max_hold=60)
+        r_high = simulate_fast(spread, z, std, cost_bps=8.0, entry_z=3.0,
+                               exit_z=0.0, vol_mult=0, cooldown=0, max_hold=60)
+
+        if r_low is not None:
+            if r_high is not None:
+                assert r_high["trades"] <= r_low["trades"]
+            # If r_high is None, it has fewer trades (< 5), which is correct
+
+    def test_nan_z_scores_skipped(self):
+        """NaN z-scores should be silently skipped, not crash."""
+        n = 200
+        spread = np.random.randn(n) * 10
+        z = np.full(n, np.nan)
+        std = np.ones(n) * 5.0
+
+        result = simulate_fast(spread, z, std, cost_bps=5.0, entry_z=2.0,
+                               exit_z=0.0, vol_mult=0, cooldown=0, max_hold=0)
+        assert result is None  # No valid z-scores → no trades
+
+    def test_max_hold_forces_timeout(self):
+        """max_hold should force exit even without signal."""
+        n = 200
+        spread = np.zeros(n)
+        z = np.zeros(n)
+        std = np.ones(n) * 100.0
+
+        # Entry at index 10, then z never reaches exit threshold
+        z[10] = 3.0
+        spread[10] = 50.0
+        # z stays above exit threshold (0.0) for all subsequent indices
+        z[11:] = 0.5
+        spread[11:] = 45.0
+
+        # Need at least 5 repeated patterns for simulate_fast to return non-None
+        for offset in range(0, 100, 20):
+            if offset + 10 < n:
+                z[offset + 10] = 3.0
+                spread[offset + 10] = 50.0
+
+        result = simulate_fast(spread, z, std, cost_bps=5.0, entry_z=2.0,
+                               exit_z=-10.0,  # exit_z very negative, never triggers on signal
+                               vol_mult=0, cooldown=0, max_hold=5)
+        if result is not None:
+            assert result["timeout_pct"] > 0
+
+
+class TestPrecomputeRolling:
+    """Tests for rolling z-score precomputation."""
+
+    def test_nan_at_start(self):
+        """First (window-1) values should be NaN."""
+        spread = np.arange(100, dtype=float)
+        result = precompute_rolling(spread, [10])
+        z = result[10]["z"]
+        assert np.all(np.isnan(z[:9]))
+        assert not np.isnan(z[9])  # First valid at index 9
+
+    def test_zero_std_produces_nan_zscore(self):
+        """Constant spread within window should produce NaN z-score."""
+        spread = np.ones(50) * 5.0
+        result = precompute_rolling(spread, [10])
+        # All std = 0, so z should be NaN
+        z = result[10]["z"]
+        assert np.all(np.isnan(z))
+
+    def test_multiple_windows(self):
+        """Should compute for all requested windows."""
+        spread = np.random.randn(200)
+        result = precompute_rolling(spread, [10, 30, 60])
+        assert set(result.keys()) == {10, 30, 60}
+        for w in [10, 30, 60]:
+            assert "z" in result[w]
+            assert "std" in result[w]
+            assert len(result[w]["z"]) == 200
+
+    def test_window_larger_than_data(self):
+        """Window > data length should produce all-NaN."""
+        spread = np.random.randn(10)
+        result = precompute_rolling(spread, [50])
+        assert np.all(np.isnan(result[50]["z"]))
+
+
+# ======================================================================
+# Bellman-Ford cycle detection
+# ======================================================================
+
+from scripts.bellman_ford_arbitrage import (
+    detect_negative_cycles,
+    _extract_cycle,
+    _final_cash_from_log_cost,
+)
+
+
+class TestFinalCashFromLogCost:
+    """Tests for log-space to cash conversion."""
+
+    def test_zero_cost_returns_initial(self):
+        assert _final_cash_from_log_cost(1000.0, 0.0) == pytest.approx(1000.0)
+
+    def test_negative_cost_means_profit(self):
+        """Negative log cost = profitable cycle (exp(-(-x)) = exp(x) > 1)."""
+        result = _final_cash_from_log_cost(1000.0, -0.01)
+        assert result > 1000.0
+
+    def test_positive_cost_means_loss(self):
+        result = _final_cash_from_log_cost(1000.0, 0.01)
+        assert result < 1000.0
+
+    def test_known_value(self):
+        """exp(-(-ln(1.05))) = exp(ln(1.05)) = 1.05 → 5% profit."""
+        log_cost = -math.log(1.05)
+        result = _final_cash_from_log_cost(1000.0, log_cost)
+        assert result == pytest.approx(1050.0, abs=0.01)
+
+    def test_zero_initial_cash(self):
+        assert _final_cash_from_log_cost(0.0, -1.0) == 0.0
+
+
+class TestDetectNegativeCycles:
+    """Tests for Bellman-Ford negative cycle detection."""
+
+    def test_empty_graph(self):
+        assert detect_negative_cycles({}, {}) == []
+
+    def test_no_edges(self):
+        nodes = {("ex", "A"): {}, ("ex", "B"): {}}
+        assert detect_negative_cycles(nodes, {}) == []
+
+    def test_simple_positive_cycle(self):
+        """All positive costs → no arbitrage."""
+        nodes = {"A": {}, "B": {}, "C": {}}
+        adj = {
+            "A": [{"to": "B", "cost": 0.1}],
+            "B": [{"to": "C", "cost": 0.1}],
+            "C": [{"to": "A", "cost": 0.1}],
+        }
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) == 0
+
+    def test_simple_negative_cycle(self):
+        """Negative cycle should be detected when cycle < total nodes.
+        _extract_cycle(max_steps=n) needs the cycle length < n to detect,
+        so we add an extra unconnected node."""
+        nodes = {"A": {}, "B": {}, "C": {}, "X": {}}  # X is not in cycle
+        adj = {
+            "A": [{"to": "B", "cost": -0.1}],
+            "B": [{"to": "C", "cost": -0.1}],
+            "C": [{"to": "A", "cost": -0.1}],  # 3-node cycle, 4 total nodes
+        }
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) >= 1
+
+    def test_mixed_edges_net_negative(self):
+        """Some positive, some negative edges, net negative cycle."""
+        nodes = {"A": {}, "B": {}, "C": {}, "X": {}}
+        adj = {
+            "A": [{"to": "B", "cost": 0.05}],
+            "B": [{"to": "C", "cost": -0.3}],
+            "C": [{"to": "A", "cost": 0.05}],  # net = -0.2
+        }
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) >= 1
+
+    def test_disconnected_graph(self):
+        """Disconnected components with no cycle."""
+        nodes = {"A": {}, "B": {}, "C": {}, "D": {}}
+        adj = {
+            "A": [{"to": "B", "cost": 0.1}],
+            "C": [{"to": "D", "cost": 0.1}],
+        }
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) == 0
+
+    def test_self_loop_negative(self):
+        """A self-loop with negative cost should be detected.
+        Need extra nodes so _extract_cycle has enough steps."""
+        nodes = {"A": {}, "B": {}}
+        adj = {"A": [{"to": "A", "cost": -0.1}], "B": []}
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) >= 1
+
+    def test_cycle_extraction_boundary_bug(self):
+        """Known edge case: _extract_cycle(max_steps=n) misses cycles
+        when cycle length == n (Hamiltonian cycles). The extraction loop
+        needs len(cycle)+1 steps to revisit the start node, but only has n.
+        This test documents current behavior — fixing _extract_cycle
+        to use max_steps=2*n would resolve this."""
+        nodes = {"A": {}, "B": {}, "C": {}}
+        adj = {
+            "A": [{"to": "B", "cost": -0.1}],
+            "B": [{"to": "C", "cost": -0.1}],
+            "C": [{"to": "A", "cost": -0.1}],
+        }
+        # 3 nodes, cycle length 3 → extraction needs 4 steps but has only 3
+        cycles = detect_negative_cycles(nodes, adj)
+        # KNOWN BUG: returns [] even though cycle exists. When fixed, change to >= 1.
+        assert len(cycles) == 0
+
+
+class TestExtractCycle:
+    """Tests for cycle extraction from predecessor map."""
+
+    def test_simple_cycle(self):
+        pred = {"A": "C", "B": "A", "C": "B"}
+        cycle = _extract_cycle("A", pred, max_steps=10)
+        assert cycle is not None
+        assert len(cycle) >= 3
+        # Should form a cycle: ends with same node as start
+        assert cycle[0] == cycle[-1]
+
+    def test_no_cycle_returns_none(self):
+        pred = {"A": "B", "B": "C", "C": None}
+        cycle = _extract_cycle("A", pred, max_steps=10)
+        assert cycle is None
+
+    def test_max_steps_exceeded(self):
+        """Long chain without cycle should return None."""
+        # Create a long chain: A→B→C→D→...
+        pred = {}
+        nodes = [f"N{i}" for i in range(100)]
+        for i in range(1, 100):
+            pred[nodes[i]] = nodes[i-1]
+        pred[nodes[0]] = None
+        cycle = _extract_cycle(nodes[50], pred, max_steps=10)
+        assert cycle is None
+
+
+# ======================================================================
+# Fee lookups (scripts/fees.py)
+# ======================================================================
+
+from scripts.fees import (
+    get_taker_fee,
+    get_maker_fee,
+    get_network_gas_fee,
+    get_min_portfolio_threshold,
+    TRADING_FEES_TAKER,
+    TRADING_FEES_MAKER,
+)
+
+
+class TestFeeLookups:
+    """Regression tests to pin known fee values and prevent silent changes."""
+
+    def test_binance_fees(self):
+        assert get_taker_fee("binance") == 0.0010
+        assert get_maker_fee("binance") == 0.0010
+
+    def test_mexc_zero_maker(self):
+        """MEXC's zero maker fee is a key part of our execution strategy."""
+        assert get_maker_fee("mexc") == 0.0
+        assert get_taker_fee("mexc") == 0.0005
+
+    def test_cryptocom_fees(self):
+        assert get_taker_fee("cryptocom") == 0.00075
+        assert get_maker_fee("cryptocom") == 0.00075
+
+    def test_kraken_high_taker(self):
+        """Kraken is expensive — confirm we're accounting for it."""
+        assert get_taker_fee("kraken") == 0.0040
+
+    def test_unknown_exchange_returns_none(self):
+        assert get_taker_fee("nonexistent_exchange") is None
+        assert get_maker_fee("nonexistent_exchange") is None
+
+    def test_all_exchanges_have_both_fees(self):
+        """Every exchange in taker dict should also be in maker dict."""
+        for ex in TRADING_FEES_TAKER:
+            assert ex in TRADING_FEES_MAKER, f"{ex} missing from TRADING_FEES_MAKER"
+
+    def test_maker_lte_taker(self):
+        """Maker fee should be <= taker fee for all exchanges."""
+        for ex in TRADING_FEES_TAKER:
+            assert TRADING_FEES_MAKER[ex] <= TRADING_FEES_TAKER[ex], (
+                f"{ex}: maker={TRADING_FEES_MAKER[ex]} > taker={TRADING_FEES_TAKER[ex]}"
+            )
+
+    def test_gas_fee_known_chains(self):
+        assert get_network_gas_fee("ETH") > 0
+        assert get_network_gas_fee("SOL") > 0
+        assert get_network_gas_fee("TRX") >= 0
+
+    def test_gas_fee_unknown_chain(self):
+        assert get_network_gas_fee("NONEXISTENT") == 0.0
+
+    def test_gas_fee_case_insensitive(self):
+        """Chain name should be case-insensitive."""
+        assert get_network_gas_fee("eth") == get_network_gas_fee("ETH")
+
+    def test_min_portfolio_threshold_defaults(self):
+        """Unknown chain should return the default threshold."""
+        result = get_min_portfolio_threshold("NONEXISTENT")
+        assert result > 0  # Should be DEFAULT_MIN_PORTFOLIO
+
+
+# ======================================================================
+# Price normalization (scripts/data.py)
+# ======================================================================
+
+from scripts.data import normalize_price_to_usd, COIN_MARKETS
+
+
+class TestNormalizePriceToUsd:
+    """Regression tests for price normalization."""
+
+    def test_direct_usd_pair(self):
+        """USDC/USD at mid=1.0001 → 1.0001 USD per USDC."""
+        assert normalize_price_to_usd("USDC", "USDC/USD", 1.0001) == pytest.approx(1.0001)
+
+    def test_usdt_quote(self):
+        """BTC/USDT at mid=50000 → 50000 USD per BTC."""
+        assert normalize_price_to_usd("BTC", "BTC/USDT", 50000.0) == pytest.approx(50000.0)
+
+    def test_usdc_quote(self):
+        """USDT/USDC at mid=0.9999 → 0.9999 USD per USDT."""
+        assert normalize_price_to_usd("USDT", "USDT/USDC", 0.9999) == pytest.approx(0.9999)
+
+    def test_usdc_usdt_inversion_for_usdt(self):
+        """USDC/USDT at mid=1.0002 → USDT price = 1/1.0002 ≈ 0.9998."""
+        result = normalize_price_to_usd("USDT", "USDC/USDT", 1.0002)
+        assert result == pytest.approx(1.0 / 1.0002, rel=1e-6)
+
+    def test_usdt_dai_inversion(self):
+        """USDT/DAI at mid=1.001 → DAI price = 1/1.001 ≈ 0.999."""
+        result = normalize_price_to_usd("DAI", "USDT/DAI", 1.001)
+        assert result == pytest.approx(1.0 / 1.001, rel=1e-6)
+
+    def test_unknown_pair_returns_none(self):
+        assert normalize_price_to_usd("XYZ", "ABC/DEF", 1.0) is None
+
+    def test_volatile_asset_usdt(self):
+        """WIF/USDT at mid=2.5 → 2.5 USD."""
+        assert normalize_price_to_usd("WIF", "WIF/USDT", 2.5) == pytest.approx(2.5)
+
+
+class TestCoinMarkets:
+    """Regression tests for market configuration."""
+
+    def test_wif_binance_exists(self):
+        """WIF on Binance is a key trading pair."""
+        market = COIN_MARKETS.get("WIF", {}).get("binance")
+        assert market is not None
+        assert "WIF" in market
+
+    def test_pepe_binance_exists(self):
+        market = COIN_MARKETS.get("PEPE", {}).get("binance")
+        assert market is not None
+
+    def test_crv_cryptocom_exists(self):
+        market = COIN_MARKETS.get("CRV", {}).get("cryptocom")
+        assert market is not None
+
+    def test_nonexistent_asset_returns_empty(self):
+        """Unknown asset should return empty dict or None from .get()."""
+        result = COIN_MARKETS.get("DOESNOTEXIST", {})
+        assert len(result) == 0
+
+
+# ======================================================================
+# PaperTrader integration tests
+# ======================================================================
+
+class TestPaperTraderSignalFlow:
+    """Integration tests for PaperTrader's tick→signal→trade pipeline."""
+
+    def _make_trader(self, tmpdir):
+        """Create a PaperTrader with temp output dir."""
+        cfg = Config(
+            asset="WIF",
+            exchange_a="binance",
+            exchange_b="cryptocom",
+            strategy="zscore",
+            entry_z=2.0,
+            exit_z=0.0,
+            warmup=10,
+            max_holding_sec=60,
+            vol_filter_mult=0,  # disable vol filter for testing
+            cooldown_ticks=0,
+            zscore_window=10,
+            slippage_bps=2.0,
+            output_dir=str(tmpdir),
+        )
+        return PaperTrader(cfg)
+
+    def test_tick_before_both_sides(self, tmp_path):
+        """Ticking only one exchange should not produce a spread."""
+        trader = self._make_trader(tmp_path)
+        try:
+            now = time.time()
+            trader.on_tick(Tick(ts=now, exchange="binance", bid=1.0, ask=1.01, mid=1.005))
+            assert len(trader.state.spread_history) == 0
+        finally:
+            trader.close()
+
+    def test_tick_both_sides_produces_spread(self, tmp_path):
+        """Ticking both exchanges should produce a spread entry."""
+        trader = self._make_trader(tmp_path)
+        try:
+            now = time.time()
+            trader.on_tick(Tick(ts=now, exchange="binance", bid=1.0, ask=1.01, mid=1.005))
+            trader.on_tick(Tick(ts=now, exchange="cryptocom", bid=1.01, ask=1.02, mid=1.015))
+            assert len(trader.state.spread_history) == 1
+        finally:
+            trader.close()
+
+    def test_stale_tick_skipped(self, tmp_path):
+        """Ticks older than 10s should not produce a spread."""
+        trader = self._make_trader(tmp_path)
+        try:
+            now = time.time()
+            trader.on_tick(Tick(ts=now, exchange="binance", bid=1.0, ask=1.01, mid=1.005))
+            trader.on_tick(Tick(ts=now - 15, exchange="cryptocom", bid=1.01, ask=1.02, mid=1.015))
+            assert len(trader.state.spread_history) == 0
+        finally:
+            trader.close()
+
+    def test_warmup_blocks_signals(self, tmp_path):
+        """No signals should fire before warmup ticks are collected."""
+        trader = self._make_trader(tmp_path)
+        try:
+            now = time.time()
+            for i in range(5):  # Less than warmup=10
+                trader.on_tick(Tick(ts=now + i, exchange="binance", bid=1.0, ask=1.01, mid=1.005))
+                trader.on_tick(Tick(ts=now + i, exchange="cryptocom", bid=1.01, ask=1.02, mid=1.015))
+            trader.check_signals()
+            assert trader.state.position is None
+            assert len(trader.state.trades) == 0
+        finally:
+            trader.close()
+
+    def test_pnl_direction_short_spread(self, tmp_path):
+        """Short spread: profit = entry_spread - exit_spread - costs."""
+        trader = self._make_trader(tmp_path)
+        try:
+            # Manually set position
+            trader.state.position = type('Position', (), {
+                'entry_time': time.time() - 10,
+                'direction': 'short_spread',
+                'entry_spread': 50.0,
+                'entry_price_a': 1.0,
+                'entry_price_b': 1.005,
+                'entry_bid_a': 0.999,
+                'entry_ask_a': 1.001,
+                'entry_bid_b': 1.004,
+                'entry_ask_b': 1.006,
+            })()
+            trader.last_tick_a = Tick(ts=time.time(), exchange="binance", bid=1.0, ask=1.01, mid=1.005)
+            trader.last_tick_b = Tick(ts=time.time(), exchange="cryptocom", bid=1.01, ask=1.02, mid=1.015)
+
+            trader._close_position(30.0, "signal")
+
+            assert len(trader.state.trades) == 1
+            trade = trader.state.trades[0]
+            # gross = 50 - 30 = 20 bps
+            assert trade.gross_pnl_bps == pytest.approx(20.0, abs=0.01)
+            # net = 20 - fees - slippage
+            assert trade.net_pnl_bps < trade.gross_pnl_bps
+        finally:
+            trader.close()
+
+    def test_pnl_direction_long_spread(self, tmp_path):
+        """Long spread: profit = exit_spread - entry_spread - costs."""
+        trader = self._make_trader(tmp_path)
+        try:
+            trader.state.position = type('Position', (), {
+                'entry_time': time.time() - 10,
+                'direction': 'long_spread',
+                'entry_spread': 30.0,
+                'entry_price_a': 1.0,
+                'entry_price_b': 1.003,
+                'entry_bid_a': 0.999,
+                'entry_ask_a': 1.001,
+                'entry_bid_b': 1.002,
+                'entry_ask_b': 1.004,
+            })()
+            trader.last_tick_a = Tick(ts=time.time(), exchange="binance", bid=1.0, ask=1.01, mid=1.005)
+            trader.last_tick_b = Tick(ts=time.time(), exchange="cryptocom", bid=1.01, ask=1.02, mid=1.015)
+
+            trader._close_position(50.0, "signal")
+
+            assert len(trader.state.trades) == 1
+            trade = trader.state.trades[0]
+            # gross = 50 - 30 = 20 bps
+            assert trade.gross_pnl_bps == pytest.approx(20.0, abs=0.01)
+        finally:
+            trader.close()
+
+    def test_close_position_when_none(self, tmp_path):
+        """Closing with no position should be a no-op."""
+        trader = self._make_trader(tmp_path)
+        try:
+            trader._close_position(10.0, "signal")
+            assert len(trader.state.trades) == 0
+        finally:
+            trader.close()
+
+    def test_latency_tracking(self, tmp_path):
+        """Latency samples should be populated after ticks."""
+        trader = self._make_trader(tmp_path)
+        try:
+            now = time.time()
+            trader.on_tick(Tick(ts=now, exchange="binance", bid=1.0, ask=1.01, mid=1.005))
+            trader.on_tick(Tick(ts=now, exchange="cryptocom", bid=1.01, ask=1.02, mid=1.015))
+            assert len(trader.state.latency_samples) >= 1
+            assert all(s > 0 for s in trader.state.latency_samples)
+        finally:
+            trader.close()
+
+
+# ======================================================================
+# Edge cases & invariants
+# ======================================================================
+
+class TestInvariants:
+    """Cross-cutting invariants that should always hold."""
+
+    def test_spread_bps_scale(self):
+        """1% price difference = 100 bps."""
+        assert compute_spread_bps(100.0, 101.0) == pytest.approx(100.0, abs=0.01)
+        assert compute_spread_bps(100.0, 100.1) == pytest.approx(10.0, abs=0.01)
+        assert compute_spread_bps(100.0, 100.01) == pytest.approx(1.0, abs=0.01)
+
+    def test_fee_bps_consistency(self):
+        """Fee in bps = fee_decimal * 10000."""
+        for ex in TRADING_FEES_TAKER:
+            fee_decimal = TRADING_FEES_TAKER[ex]
+            fee_bps = fee_decimal * 10_000
+            assert 0 <= fee_bps <= 100, f"{ex} fee {fee_bps} bps seems wrong"
+
+    def test_simulate_pnl_is_sum_of_trades(self):
+        """Total PnL should equal sum of individual trade PnLs."""
+        np.random.seed(42)
+        spread = np.zeros(500)
+        for i in range(1, 500):
+            spread[i] = spread[i-1] * 0.85 + np.random.randn() * 10.0
+        rolling = precompute_rolling(spread, [30])
+        z = rolling[30]["z"]
+        std = rolling[30]["std"]
+
+        result = simulate_fast(spread, z, std, cost_bps=8.0, entry_z=1.5,
+                               exit_z=0.3, vol_mult=0, cooldown=0, max_hold=30)
+        if result is not None:
+            assert result["net_pnl"] == pytest.approx(
+                result["avg_net"] * result["trades"], abs=0.1
+            )
+
+    def test_ou_params_sign_convention(self):
+        """theta should be positive for mean-reverting series."""
+        np.random.seed(42)
+        x = np.zeros(300)
+        for i in range(1, 300):
+            x[i] = x[i-1] * 0.8 + np.random.randn()
+        theta, mu, sigma = estimate_ou_params(x)
+        if theta is not None:
+            assert theta > 0
+            assert sigma > 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -537,21 +537,17 @@ class TestDetectNegativeCycles:
         assert len(cycles) >= 1
 
     def test_cycle_extraction_boundary_bug(self):
-        """Known edge case: _extract_cycle(max_steps=n) misses cycles
-        when cycle length == n (Hamiltonian cycles). The extraction loop
-        needs len(cycle)+1 steps to revisit the start node, but only has n.
-        This test documents current behavior — fixing _extract_cycle
-        to use max_steps=2*n would resolve this."""
+        """Regression: _extract_cycle must handle cycles where cycle length
+        equals total node count (Hamiltonian cycles). Fixed by using
+        max_steps=2*n instead of max_steps=n."""
         nodes = {"A": {}, "B": {}, "C": {}}
         adj = {
             "A": [{"to": "B", "cost": -0.1}],
             "B": [{"to": "C", "cost": -0.1}],
             "C": [{"to": "A", "cost": -0.1}],
         }
-        # 3 nodes, cycle length 3 → extraction needs 4 steps but has only 3
         cycles = detect_negative_cycles(nodes, adj)
-        # KNOWN BUG: returns [] even though cycle exists. When fixed, change to >= 1.
-        assert len(cycles) == 0
+        assert len(cycles) >= 1
 
 
 class TestExtractCycle:


### PR DESCRIPTION
## Summary

Fixes #69 — `_extract_cycle(max_steps=n)` missed negative cycles when cycle length equaled total node count.

## Changes

- **scripts/bellman_ford_arbitrage.py**: Changed `max_steps=n` → `max_steps=2*n` in the `_extract_cycle` call. Predecessor chains in Bellman-Ford can revisit nodes in cycles, so `n` steps is insufficient for Hamiltonian cycles (where the cycle visits all `n` nodes).

- **tests/test_core.py**: Converted `test_cycle_extraction_boundary_bug` from documenting the bug (`assert len(cycles) == 0`) to a regression test (`assert len(cycles) >= 1`).

## Testing

88/88 tests pass. The previously-failing boundary case now correctly detects the 3-node Hamiltonian negative cycle.