### PR TITLE
Fix: Bellman-Ford Hamiltonian cycle bug + regression tests

### DIFF
--- a/scripts/bellman_ford_arbitrage.py
+++ b/scripts/bellman_ford_arbitrage.py
@@ -102,7 +102,9 @@ def detect_negative_cycles(
             # If we can still relax, there's a negative cycle
             if dist[u] + cost < dist[v]:
                 # Trace back to find the cycle
-                cycle = _extract_cycle(v, pred, n)
+                # Use 2*n steps: predecessor chains in cycles can revisit nodes,
+                # and n steps is insufficient for Hamiltonian cycles (cycle len == n)
+                cycle = _extract_cycle(v, pred, 2 * n)
                 if cycle and tuple(cycle) not in visited_cycles:
                     visited_cycles.add(tuple(cycle))
                     negative_cycles.append(cycle)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,298 @@
+"""
+Regression & benchmark tests for core stablecoin arbitrage algorithms.
+
+Covers:
+  - Bellman-Ford negative cycle detection
+  - Cycle extraction from predecessor maps
+  - Final cash from log cost (path profitability)
+  - Fee lookups and invariants
+  - Price normalization
+  - Coin market configuration
+
+Run:
+    pytest tests/test_core.py -v
+"""
+
+import math
+import numpy as np
+import pytest
+import sys
+import os
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ======================================================================
+# Bellman-Ford cycle detection
+# ======================================================================
+
+from scripts.bellman_ford_arbitrage import (
+    detect_negative_cycles,
+    _extract_cycle,
+    _final_cash_from_log_cost,
+)
+
+
+class TestFinalCashFromLogCost:
+    """Tests for log-space to cash conversion."""
+
+    def test_zero_cost_returns_initial(self):
+        assert _final_cash_from_log_cost(1000.0, 0.0) == pytest.approx(1000.0)
+
+    def test_negative_cost_means_profit(self):
+        """Negative log cost = profitable cycle (exp(-(-x)) = exp(x) > 1)."""
+        result = _final_cash_from_log_cost(1000.0, -0.01)
+        assert result > 1000.0
+
+    def test_positive_cost_means_loss(self):
+        result = _final_cash_from_log_cost(1000.0, 0.01)
+        assert result < 1000.0
+
+    def test_known_value(self):
+        """exp(-(-ln(1.05))) = exp(ln(1.05)) = 1.05 → 5% profit."""
+        log_cost = -math.log(1.05)
+        result = _final_cash_from_log_cost(1000.0, log_cost)
+        assert result == pytest.approx(1050.0, abs=0.01)
+
+    def test_zero_initial_cash(self):
+        assert _final_cash_from_log_cost(0.0, -1.0) == 0.0
+
+
+class TestDetectNegativeCycles:
+    """Tests for Bellman-Ford negative cycle detection."""
+
+    def test_empty_graph(self):
+        assert detect_negative_cycles({}, {}) == []
+
+    def test_no_edges(self):
+        nodes = {("ex", "A"): {}, ("ex", "B"): {}}
+        assert detect_negative_cycles(nodes, {}) == []
+
+    def test_simple_positive_cycle(self):
+        """All positive costs → no arbitrage."""
+        nodes = {"A": {}, "B": {}, "C": {}}
+        adj = {
+            "A": [{"to": "B", "cost": 0.1}],
+            "B": [{"to": "C", "cost": 0.1}],
+            "C": [{"to": "A", "cost": 0.1}],
+        }
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) == 0
+
+    def test_simple_negative_cycle(self):
+        """Negative cycle should be detected when cycle < total nodes.
+        _extract_cycle(max_steps=n) needs the cycle length < n to detect,
+        so we add an extra unconnected node."""
+        nodes = {"A": {}, "B": {}, "C": {}, "X": {}}  # X is not in cycle
+        adj = {
+            "A": [{"to": "B", "cost": -0.1}],
+            "B": [{"to": "C", "cost": -0.1}],
+            "C": [{"to": "A", "cost": -0.1}],  # 3-node cycle, 4 total nodes
+        }
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) >= 1
+
+    def test_mixed_edges_net_negative(self):
+        """Some positive, some negative edges, net negative cycle."""
+        nodes = {"A": {}, "B": {}, "C": {}, "X": {}}
+        adj = {
+            "A": [{"to": "B", "cost": 0.05}],
+            "B": [{"to": "C", "cost": -0.3}],
+            "C": [{"to": "A", "cost": 0.05}],  # net = -0.2
+        }
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) >= 1
+
+    def test_disconnected_graph(self):
+        """Disconnected components with no cycle."""
+        nodes = {"A": {}, "B": {}, "C": {}, "D": {}}
+        adj = {
+            "A": [{"to": "B", "cost": 0.1}],
+            "C": [{"to": "D", "cost": 0.1}],
+        }
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) == 0
+
+    def test_self_loop_negative(self):
+        """A self-loop with negative cost should be detected.
+        Need extra nodes so _extract_cycle has enough steps."""
+        nodes = {"A": {}, "B": {}}
+        adj = {"A": [{"to": "A", "cost": -0.1}], "B": []}
+        cycles = detect_negative_cycles(nodes, adj)
+        assert len(cycles) >= 1
+
+    def test_cycle_extraction_boundary_bug(self):
+        """Known edge case: _extract_cycle(max_steps=n) misses cycles
+        when cycle length == n (Hamiltonian cycles). The extraction loop
+        needs len(cycle)+1 steps to revisit the start node, but only has n.
+        This test documents current behavior — fixing _extract_cycle
+        to use max_steps=2*n would resolve this."""
+        nodes = {"A": {}, "B": {}, "C": {}}
+        adj = {
+            "A": [{"to": "B", "cost": -0.1}],
+            "B": [{"to": "C", "cost": -0.1}],
+            "C": [{"to": "A", "cost": -0.1}],
+        }
+        # 3 nodes, cycle length 3 → extraction needs 4 steps but has only 3
+        cycles = detect_negative_cycles(nodes, adj)
+        # KNOWN BUG: returns [] even though cycle exists. When fixed, change to >= 1.
+        assert len(cycles) == 0
+
+
+class TestExtractCycle:
+    """Tests for cycle extraction from predecessor map."""
+
+    def test_simple_cycle(self):
+        pred = {"A": "C", "B": "A", "C": "B"}
+        cycle = _extract_cycle("A", pred, max_steps=10)
+        assert cycle is not None
+        assert len(cycle) >= 3
+        # Should form a cycle: ends with same node as start
+        assert cycle[0] == cycle[-1]
+
+    def test_no_cycle_returns_none(self):
+        pred = {"A": "B", "B": "C", "C": None}
+        cycle = _extract_cycle("A", pred, max_steps=10)
+        assert cycle is None
+
+    def test_max_steps_exceeded(self):
+        """Long chain without cycle should return None."""
+        pred = {}
+        nodes = [f"N{i}" for i in range(100)]
+        for i in range(1, 100):
+            pred[nodes[i]] = nodes[i-1]
+        pred[nodes[0]] = None
+        cycle = _extract_cycle(nodes[50], pred, max_steps=10)
+        assert cycle is None
+
+
+# ======================================================================
+# Fee lookups (scripts/fees.py)
+# ======================================================================
+
+from scripts.fees import (
+    get_taker_fee,
+    get_maker_fee,
+    get_network_gas_fee,
+    get_min_portfolio_threshold,
+    TRADING_FEES_TAKER,
+    TRADING_FEES_MAKER,
+)
+
+
+class TestFeeLookups:
+    """Regression tests to pin known fee values and prevent silent changes."""
+
+    def test_binance_fees(self):
+        assert get_taker_fee("binance") == 0.0010
+        assert get_maker_fee("binance") == 0.0010
+
+    def test_mexc_zero_maker(self):
+        """MEXC's zero maker fee is a key part of our execution strategy."""
+        assert get_maker_fee("mexc") == 0.0
+        assert get_taker_fee("mexc") == 0.0005
+
+    def test_cryptocom_fees(self):
+        assert get_taker_fee("cryptocom") == 0.00075
+        assert get_maker_fee("cryptocom") == 0.00075
+
+    def test_kraken_high_taker(self):
+        """Kraken is expensive — confirm we're accounting for it."""
+        assert get_taker_fee("kraken") == 0.0040
+
+    def test_unknown_exchange_returns_none(self):
+        assert get_taker_fee("nonexistent_exchange") is None
+        assert get_maker_fee("nonexistent_exchange") is None
+
+    def test_all_exchanges_have_both_fees(self):
+        """Every exchange in taker dict should also be in maker dict."""
+        for ex in TRADING_FEES_TAKER:
+            assert ex in TRADING_FEES_MAKER, f"{ex} missing from TRADING_FEES_MAKER"
+
+    def test_maker_lte_taker(self):
+        """Maker fee should be <= taker fee for all exchanges."""
+        for ex in TRADING_FEES_TAKER:
+            assert TRADING_FEES_MAKER[ex] <= TRADING_FEES_TAKER[ex], (
+                f"{ex}: maker={TRADING_FEES_MAKER[ex]} > taker={TRADING_FEES_TAKER[ex]}"
+            )
+
+    def test_gas_fee_known_chains(self):
+        assert get_network_gas_fee("ETH") > 0
+        assert get_network_gas_fee("SOL") > 0
+        assert get_network_gas_fee("TRX") >= 0
+
+    def test_gas_fee_unknown_chain(self):
+        assert get_network_gas_fee("NONEXISTENT") == 0.0
+
+    def test_gas_fee_case_insensitive(self):
+        """Chain name should be case-insensitive."""
+        assert get_network_gas_fee("eth") == get_network_gas_fee("ETH")
+
+    def test_min_portfolio_threshold_defaults(self):
+        """Unknown chain should return the default threshold."""
+        result = get_min_portfolio_threshold("NONEXISTENT")
+        assert result > 0  # Should be DEFAULT_MIN_PORTFOLIO
+
+
+# ======================================================================
+# Price normalization (scripts/data.py)
+# ======================================================================
+
+from scripts.data import normalize_price_to_usd, COIN_MARKETS
+
+
+class TestNormalizePriceToUsd:
+    """Regression tests for price normalization."""
+
+    def test_direct_usd_pair(self):
+        """USDC/USD at mid=1.0001 → 1.0001 USD per USDC."""
+        assert normalize_price_to_usd("USDC", "USDC/USD", 1.0001) == pytest.approx(1.0001)
+
+    def test_usdt_quote(self):
+        """BTC/USDT at mid=50000 → 50000 USD per BTC."""
+        assert normalize_price_to_usd("BTC", "BTC/USDT", 50000.0) == pytest.approx(50000.0)
+
+    def test_usdc_quote(self):
+        """USDT/USDC at mid=0.9999 → 0.9999 USD per USDT."""
+        assert normalize_price_to_usd("USDT", "USDT/USDC", 0.9999) == pytest.approx(0.9999)
+
+    def test_usdc_usdt_inversion_for_usdt(self):
+        """USDC/USDT at mid=1.0002 → USDT price = 1/1.0002 ≈ 0.9998."""
+        result = normalize_price_to_usd("USDT", "USDC/USDT", 1.0002)
+        assert result == pytest.approx(1.0 / 1.0002, rel=1e-6)
+
+    def test_usdt_dai_inversion(self):
+        """USDT/DAI at mid=1.001 → DAI price = 1/1.001 ≈ 0.999."""
+        result = normalize_price_to_usd("DAI", "USDT/DAI", 1.001)
+        assert result == pytest.approx(1.0 / 1.001, rel=1e-6)
+
+    def test_unknown_pair_returns_none(self):
+        assert normalize_price_to_usd("XYZ", "ABC/DEF", 1.0) is None
+
+    def test_volatile_asset_usdt(self):
+        """WIF/USDT at mid=2.5 → 2.5 USD."""
+        assert normalize_price_to_usd("WIF", "WIF/USDT", 2.5) == pytest.approx(2.5)
+
+
+class TestCoinMarkets:
+    """Regression tests for market configuration."""
+
+    def test_wif_binance_exists(self):
+        """WIF on Binance is a key trading pair."""
+        market = COIN_MARKETS.get("WIF", {}).get("binance")
+        assert market is not None
+        assert "WIF" in market
+
+    def test_pepe_binance_exists(self):
+        market = COIN_MARKETS.get("PEPE", {}).get("binance")
+        assert market is not None
+
+    def test_crv_cryptocom_exists(self):
+        market = COIN_MARKETS.get("CRV", {}).get("cryptocom")
+        assert market is not None
+
+    def test_nonexistent_asset_returns_empty(self):
+        """Unknown asset should return empty dict or None from .get()."""
+        result = COIN_MARKETS.get("DOESNOTEXIST", {})
+        assert len(result) == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -123,21 +123,17 @@ class TestDetectNegativeCycles:
         assert len(cycles) >= 1
 
     def test_cycle_extraction_boundary_bug(self):
-        """Known edge case: _extract_cycle(max_steps=n) misses cycles
-        when cycle length == n (Hamiltonian cycles). The extraction loop
-        needs len(cycle)+1 steps to revisit the start node, but only has n.
-        This test documents current behavior — fixing _extract_cycle
-        to use max_steps=2*n would resolve this."""
+        """Regression: _extract_cycle must handle cycles where cycle length
+        equals total node count (Hamiltonian cycles). Fixed by using
+        max_steps=2*n instead of max_steps=n."""
         nodes = {"A": {}, "B": {}, "C": {}}
         adj = {
             "A": [{"to": "B", "cost": -0.1}],
             "B": [{"to": "C", "cost": -0.1}],
             "C": [{"to": "A", "cost": -0.1}],
         }
-        # 3 nodes, cycle length 3 → extraction needs 4 steps but has only 3
         cycles = detect_negative_cycles(nodes, adj)
-        # KNOWN BUG: returns [] even though cycle exists. When fixed, change to >= 1.
-        assert len(cycles) == 0
+        assert len(cycles) >= 1
 
 
 class TestExtractCycle:
@@ -278,19 +274,10 @@ class TestNormalizePriceToUsd:
 class TestCoinMarkets:
     """Regression tests for market configuration."""
 
-    def test_wif_binance_exists(self):
-        """WIF on Binance is a key trading pair."""
-        market = COIN_MARKETS.get("WIF", {}).get("binance")
-        assert market is not None
-        assert "WIF" in market
-
-    def test_pepe_binance_exists(self):
-        market = COIN_MARKETS.get("PEPE", {}).get("binance")
-        assert market is not None
-
-    def test_crv_cryptocom_exists(self):
-        market = COIN_MARKETS.get("CRV", {}).get("cryptocom")
-        assert market is not None
+    def test_stablecoin_markets_exist(self):
+        """Core stablecoins should have market entries."""
+        for coin in ["USDT", "USDC"]:
+            assert coin in COIN_MARKETS, f"{coin} missing from COIN_MARKETS"
 
     def test_nonexistent_asset_returns_empty(self):
         """Unknown asset should return empty dict or None from .get()."""


### PR DESCRIPTION
## Bellman-Ford Fix + Regression Tests

### Changes

1. **Bellman-Ford Hamiltonian cycle fix** (scripts/bellman_ford_arbitrage.py)
   - _extract_cycle(max_steps=n) fails when cycle length equals node count
   - Changed to max_steps=2*n so predecessor tracing can revisit the start node

2. **Regression test suite** (	ests/test_core.py) - 36 tests in ~1s
   - Bellman-Ford cycle detection (8 tests)
   - Cycle extraction (3 tests)
   - Final cash from log cost (5 tests)
   - Fee lookups and invariants (12 tests)
   - Price normalization (7 tests)
   - Coin market config (2 tests, stablecoin-only - excluded stat-arb assets not in this repo)

Cherry-picked from feature/strategy-engine, trimmed to stablecoin-relevant tests only.

Closes #69